### PR TITLE
provide an example for a decision with an attachment

### DIFF
--- a/app/components/docs-header.hbs
+++ b/app/components/docs-header.hbs
@@ -1,0 +1,18 @@
+<section class="region region--alt">
+  <div class="layout layout--wide">
+    <div class="tabs__wrapper">
+      <ul class="tabs" data-tabs-list>
+        <li class="tab">
+          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
+        </li>
+      </ul>
+    </div>
+
+    <div class="grid">
+      <div class="col--8-12 col--1-1--s">
+        <h1 class="h1">{{@heading}}</h1>
+         {{yield}}
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/router.js
+++ b/app/router.js
@@ -14,6 +14,7 @@ Router.map(function() {
     this.route('leidinggevenden');
     this.route('rijksregisternummer-api');
     this.route('sparql-endpoint');
+    this.route('decision-attachments');
   });
 
   this.route('route-not-found', {

--- a/app/routes/docs/decision-attachments.js
+++ b/app/routes/docs/decision-attachments.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class DocsDecisionAttachmentsRoute extends Route {
+}

--- a/app/templates/docs.hbs
+++ b/app/templates/docs.hbs
@@ -4,54 +4,62 @@
   <div class="layout layout--wide">
     <h2 class="h2">Beschikbare documentatie</h2>
     <ul class="grid grid--is-stacked js-equal-height-container">
-      <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
+      <li class="col--4-12 col--1-2--s col--12-12--xs">
         <LinkTo @route="docs.submission-api" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Meldingsplicht API
           </div>
-          <span class="doormat__text">API om een nieuwe melding aan te maken in Loket voor Lokale Besturen op basis van een publicatie. Indien al de nodige velden ingevuld zijn, kan de melding automatisch verzonden worden.</span>
         </LinkTo>
       </li>
-      <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
+      <li class="col--4-12 col--1-2--s col--12-12--xs">
         <LinkTo @route="docs.submission-annotations" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Annotaties voor automatische melding
           </div>
-          <span class="doormat__text">Annotaties die gebruikt worden bij automatische meldingen van besluiten en documenten.</span>
         </LinkTo>
       </li>
-      <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
+      <li class="col--4-12 col--1-2--s col--12-12--xs">
         <LinkTo @route="docs.publication-annotations" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Annotaties van besluiten en documenten
           </div>
-          <span class="doormat__text">Annotaties die gebruikt worden bij de publicatie van besluiten en documenten opdat ze automatisch geharvest kunnen worden.</span>
         </LinkTo>
       </li>
-      <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
+      <li class="col--4-12 col--1-2--s col--12-12--xs">
         <a href="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/" target="_blank" rel="noopener" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Besluit Publicatie
             <p><small class="uppercase text-fade"><i class="vi vi-external"></i> externe link</small></p>
           </div>
-          <span class="doormat__text">Dit applicatieprofiel definieert een specificatie voor de publicatie van notulen en besluiten van bestuursorgaan.</span>
         </a>
       </li>
-      <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
+      <li class="col--4-12 col--1-2--s col--12-12--xs">
         <a href="https://data.vlaanderen.be/doc/applicatieprofiel/mandatendatabank/" target="_blank" rel="noopener" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Mandatendatabank
             <p><small class="uppercase text-fade"><i class="vi vi-external"></i> externe link</small></p>
           </div>
-          <span class="doormat__text">Dit applicatieprofiel definieert een specificatie voor een gelinkte mandatendatabank op basis van gelinkte besluiten.</span>
         </a>
       </li>
-      <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
+      <li class="col--4-12 col--1-2--s col--12-12--xs">
         <LinkTo @route="docs.leidinggevenden" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Leidinggevenden
           </div>
-          <span class="doormat__text">De leidinggevenden databank volgt het applicatieprofiel mandatendatabank, maar werd uitgebreid met enkele subklassen en eigenschappen.</span>
+        </LinkTo>
+      </li>
+      <li class="col--4-12 col--1-2--s col--12-12--xs">
+        <LinkTo @route="docs.rijksregisternummer-api" class="doormat js-equal-height u-mobile-no-equal-height">
+          <div class="doormat__title">
+            Persoon URI [BETA]
+          </div>
+        </LinkTo>
+      </li>
+      <li class="col--4-12 col--1-2--s col--12-12--xs">
+        <LinkTo @route="docs.sparql-endpoint" class="doormat js-equal-height u-mobile-no-equal-height">
+          <div class="doormat__title">
+            SPARQL endpoint
+          </div>
         </LinkTo>
       </li>
     </ul>

--- a/app/templates/docs.hbs
+++ b/app/templates/docs.hbs
@@ -5,28 +5,28 @@
     <h2 class="h2">Beschikbare documentatie</h2>
     <ul class="grid grid--is-stacked js-equal-height-container">
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
-        {{#link-to "docs.submission-api" class="doormat js-equal-height u-mobile-no-equal-height"}}
+        <LinkTo @route="docs.submission-api" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Meldingsplicht API
           </div>
           <span class="doormat__text">API om een nieuwe melding aan te maken in Loket voor Lokale Besturen op basis van een publicatie. Indien al de nodige velden ingevuld zijn, kan de melding automatisch verzonden worden.</span>
-        {{/link-to}}
+        </LinkTo>
       </li>
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
-        {{#link-to "docs.submission-annotations" class="doormat js-equal-height u-mobile-no-equal-height"}}
+        <LinkTo @route="docs.submission-annotations" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Annotaties voor automatische melding
           </div>
           <span class="doormat__text">Annotaties die gebruikt worden bij automatische meldingen van besluiten en documenten.</span>
-        {{/link-to}}
+        </LinkTo>
       </li>
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
-        {{#link-to "docs.publication-annotations" class="doormat js-equal-height u-mobile-no-equal-height"}}
+        <LinkTo @route="docs.publication-annotations" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Annotaties van besluiten en documenten
           </div>
           <span class="doormat__text">Annotaties die gebruikt worden bij de publicatie van besluiten en documenten opdat ze automatisch geharvest kunnen worden.</span>
-        {{/link-to}}
+        </LinkTo>
       </li>
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
         <a href="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/" target="_blank" rel="noopener" class="doormat js-equal-height u-mobile-no-equal-height">
@@ -47,12 +47,12 @@
         </a>
       </li>
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
-        {{#link-to "docs.leidinggevenden" class="doormat js-equal-height u-mobile-no-equal-height"}}
+        <LinkTo @route="docs.leidinggevenden" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Leidinggevenden
           </div>
           <span class="doormat__text">De leidinggevenden databank volgt het applicatieprofiel mandatendatabank, maar werd uitgebreid met enkele subklassen en eigenschappen.</span>
-        {{/link-to}}
+        </LinkTo>
       </li>
     </ul>
   </div>
@@ -60,6 +60,6 @@
 
 <section class="region">
   <div class="layout layout--wide">
-    {{#link-to "index" class="link--icon--caret link--icon--caret--back"}}Terug naar overzicht{{/link-to}}
+    <LinkTo @route="index" class="link--icon--caret link--icon--caret--back">Terug naar overzicht</LinkTo>
   </div>
 </section>

--- a/app/templates/docs/decision-attachments.hbs
+++ b/app/templates/docs/decision-attachments.hbs
@@ -9,8 +9,8 @@
         <article class="u-spacer--large">
           <h2 class="h2">Eenvoudige bijlagen</h2>
           <p class="u-spacer">
-            Het applicatieprofiel besluit-publicatie voorziet de relatie <a href="http://data.europa.eu/eli/ontology#cites" target="_blank">eli:cites</a> voor verwijzingen naar zowel citaten als bijlagen. Het is daarom belangrijk er op te letten dat citaten enkel verwacht worden in de motivering van een besluit en niet in de andere stukken van het besluit.</p>
-          <p class="u-spacer">In het onderstaande voorbeeld wordt gelinkt naar zowel een citaat als een pdf bijlage.</p>
+            Het applicatieprofiel besluit-publicatie voorziet de relatie <a href="http://data.europa.eu/eli/ontology#related_to" target="_blank">eli:related_to</a> voor verwijzingen naar bijlagen.</p>
+          <p class="u-spacer">In het onderstaande voorbeeld wordt gelinkt een pdf bijlage.</p>
           {{#with (get-code-snippet "example-besluit-met-pdf-bijlage.html") as |snippet|}}
             <CodeBlock>{{snippet.source}}</CodeBlock>
           {{/with}}
@@ -31,9 +31,8 @@
             <p class="u-spacer">In het onderstaande voorbeeld wordt een subsidiereglement goedgekeurd, het reglement wordt als tweede besluit opgenomen in de behandeling van het agendapunt.</p>
             <ul>
               <li>Er wordt gebruikt gemaakt van de relatie prov:generated tussen de behandeling en de twee besluiten.</li>
-              <li>Met de relatie eli:cites wordt aangegeven dat het subsidiereglement een bijlage is van het goedkeuringsbesluit</li>
+              <li>Met de relatie eli:related_to wordt aangegeven dat het subsidiereglement een bijlage is van het goedkeuringsbesluit</li>
               <li>Met de relatie dct:isPartOf wordt aangegeven dat het subsidiereglement kan worden aanzien als zijnde een onderdeel van het eerste besluit</li>
-              <li><strong>TODO: motivering is eigenlijk verplicht voor een besluit, maar een reglement zal dit typisch niet hebben?</strong></li>
             </ul>
 
             {{#with (get-code-snippet "example-besluit-met-geannoteerde-bijlage.html") as |snippet|}}

--- a/app/templates/docs/decision-attachments.hbs
+++ b/app/templates/docs/decision-attachments.hbs
@@ -1,0 +1,46 @@
+<DocsHeader @heading="Bijlagen bij een besluit annoteren">
+  <p>Dit document beschrijft hoe verschillende soorten bijlagen bij een besluit geannoteerd kunnen worden. Er wordt extra aandacht besteed aan reglementaire bijlagen zoals bijvoorbeeld een subsidieregelement of aanvullend wegreglement.</p>
+</DocsHeader>
+
+<section class="region">
+  <div class="layout layout--wide">
+    <div class="grid">
+      <div class="col--8-12 col--1-1--s">
+        <article class="u-spacer--large">
+          <h2 class="h2">Eenvoudige bijlagen</h2>
+          <p class="u-spacer">
+            Het applicatieprofiel besluit-publicatie voorziet de relatie <a href="http://data.europa.eu/eli/ontology#cites" target="_blank">eli:cites</a> voor verwijzingen naar zowel citaten als bijlagen. Het is daarom belangrijk er op te letten dat citaten enkel verwacht worden in de motivering van een besluit en niet in de andere stukken van het besluit.</p>
+          <p class="u-spacer">In het onderstaande voorbeeld wordt gelinkt naar zowel een citaat als een pdf bijlage.</p>
+          {{#with (get-code-snippet "example-besluit-met-pdf-bijlage.html") as |snippet|}}
+            <CodeBlock>{{snippet.source}}</CodeBlock>
+          {{/with}}
+        </article>
+        <article class="u-spacer--large">
+          <h2 class="h2">Bijlagen die deel uitmaken van het besluit</h2>
+          <p class="u-spacer">Indien een bijlage (juridisch) kan worden aanzien als zijnde een onderdeel van het besluit worden de annotaties van de eenvoudige bijlage aangevuld om aan te duiden dat het gaat om een document onderdeel. Het applicatieprofiel besluit-publicatie voorziet hiervoor de relatie <a href="http://purl.org/dc/terms/isPartOf" target="_blank">dct:isPartOf</a> van het onderdeel naar het besluit.</p>
+          <p class="u-spacer"><strong>Opmerking:</strong> In het voorbeeld maken we gebruik van het html atribuut "rev" om deze relatie in de omgekeerde richting op te geven.</p>
+          {{#with (get-code-snippet "example-besluit-met-pdf-bijlage-als-onderdeel.html") as |snippet|}}
+            <CodeBlock>{{snippet.source}}</CodeBlock>
+          {{/with}}
+        </article>
+        <article class="u-spacer--large">
+          <h2 class="h2">Een besluit als bijlage</h2>
+          <p class="u-spacer">
+            Sommige bijlagen zijn besluiten op zich, het gaat dan voornamelijk om reglementen zoals het huishoudelijk reglement, subsdiereglementen, aanvullende verkeersreglementen, etc. Deze bijlagen dienen geannoteerd te worden als een besluit en kunnen ofwel opgenomen worden als een tweede besluit in de publicatie (inline bijlage) of als een verwijzing naar een geannoteerde publicatie.</p>
+            <h3 class="h3">Inline besluit als bijlage</h3>
+            <p class="u-spacer">In het onderstaande voorbeeld wordt een subsidiereglement goedgekeurd, het reglement wordt als tweede besluit opgenomen in de behandeling van het agendapunt.</p>
+            <ul>
+              <li>Er wordt gebruikt gemaakt van de relatie prov:generated tussen de behandeling en de twee besluiten.</li>
+              <li>Met de relatie eli:cites wordt aangegeven dat het subsidiereglement een bijlage is van het goedkeuringsbesluit</li>
+              <li>Met de relatie dct:isPartOf wordt aangegeven dat het subsidiereglement kan worden aanzien als zijnde een onderdeel van het eerste besluit</li>
+              <li><strong>TODO: motivering is eigenlijk verplicht voor een besluit, maar een reglement zal dit typisch niet hebben?</strong></li>
+            </ul>
+
+            {{#with (get-code-snippet "example-besluit-met-geannoteerde-bijlage.html") as |snippet|}}
+            <CodeBlock>{{snippet.source}}</CodeBlock>
+          {{/with}}
+        </article>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/templates/docs/leidinggevenden.hbs
+++ b/app/templates/docs/leidinggevenden.hbs
@@ -1,23 +1,8 @@
-<section class="region region--alt">
-  <div class="layout layout--wide">
-    <div class="tabs__wrapper">
-      <ul class="tabs" data-tabs-list>
-        <li class="tab">
-          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
-        </li>
-      </ul>
-    </div>
-
-    <div class="grid">
-      <div class="col--8-12 col--1-1--s">
-        <h1 class="h1">Leidinggevenden databank</h1>
-        <p>
-          De leidinggevenden databank bevat de leidinggevenden van de lokale besturen en hun verzelfstandigde entiteiten. Deze databank volgt een uitbreiding op het applicatieprofiel <a href="https://data.vlaanderen.be/doc/applicatieprofiel/mandatendatabank/" target="_blank" rel="noopener">mandatendatabank</a>. Dit document beschrijft deze uitbreiding.
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
+<DocsHeader @heading="Leidinggevenden databank">
+  <p>
+    De leidinggevenden databank bevat de leidinggevenden van de lokale besturen en hun verzelfstandigde entiteiten. Deze databank volgt een uitbreiding op het applicatieprofiel <a href="https://data.vlaanderen.be/doc/applicatieprofiel/mandatendatabank/" target="_blank" rel="noopener">mandatendatabank</a>. Dit document beschrijft deze uitbreiding.
+  </p>
+</DocsHeader>
 
 <section class="region">
   <div class="layout layout--wide">

--- a/app/templates/docs/leidinggevenden.hbs
+++ b/app/templates/docs/leidinggevenden.hbs
@@ -3,7 +3,7 @@
     <div class="tabs__wrapper">
       <ul class="tabs" data-tabs-list>
         <li class="tab">
-          {{#link-to "index" class="tab__link"}}<i class="fa fa-angle-left"></i> Terug naar overzicht{{/link-to}}
+          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
         </li>
       </ul>
     </div>

--- a/app/templates/docs/publication-annotations.hbs
+++ b/app/templates/docs/publication-annotations.hbs
@@ -3,7 +3,7 @@
     <div class="tabs__wrapper">
       <ul class="tabs" data-tabs-list>
         <li class="tab">
-          {{#link-to "index" class="tab__link"}}<i class="fa fa-angle-left"></i> Terug naar overzicht{{/link-to}}
+          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
         </li>
       </ul>
     </div>
@@ -13,7 +13,7 @@
         <h1 class="h1">Annoteren van publicaties</h1>
         <p>
           Lokale besturen publiceren documenten en beslissingen zoals agenda's, besluitenlijsten, notulen, enz. Opdat de kennis automatisch door een machine uit deze documenten ge&euml;xtraheerd kan worden, moeten ze op een correcte wijze
-          geannoteerd te worden. Deze annotaties gebeuren volgens <a href="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/" target="_blank" rel="noopener">het Besluit Publicatie applicatieprofiel</a> en de {{#link-to "docs.submission-annotations"}}annotaties voor automatische melding{{/link-to}}. Dit document beschrijft de annotaties die gebruikt worden om gepubliceerde documenten en overzichtpagina's te annoteren.
+          geannoteerd te worden. Deze annotaties gebeuren volgens <a href="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/" target="_blank" rel="noopener">het Besluit Publicatie applicatieprofiel</a> en de <LinkTo @route="docs.submission-annotations">annotaties voor automatische melding</LinkTo>. Dit document beschrijft de annotaties die gebruikt worden om gepubliceerde documenten en overzichtpagina's te annoteren.
         </p>
       </div>
     </div>

--- a/app/templates/docs/publication-annotations.hbs
+++ b/app/templates/docs/publication-annotations.hbs
@@ -1,25 +1,9 @@
-<section class="region region--alt">
-  <div class="layout layout--wide">
-    <div class="tabs__wrapper">
-      <ul class="tabs" data-tabs-list>
-        <li class="tab">
-          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
-        </li>
-      </ul>
-    </div>
-
-    <div class="grid">
-      <div class="col--8-12 col--1-1--s">
-        <h1 class="h1">Annoteren van publicaties</h1>
-        <p>
-          Lokale besturen publiceren documenten en beslissingen zoals agenda's, besluitenlijsten, notulen, enz. Opdat de kennis automatisch door een machine uit deze documenten ge&euml;xtraheerd kan worden, moeten ze op een correcte wijze
-          geannoteerd te worden. Deze annotaties gebeuren volgens <a href="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/" target="_blank" rel="noopener">het Besluit Publicatie applicatieprofiel</a> en de <LinkTo @route="docs.submission-annotations">annotaties voor automatische melding</LinkTo>. Dit document beschrijft de annotaties die gebruikt worden om gepubliceerde documenten en overzichtpagina's te annoteren.
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
-
+<DocsHeader @heading="Annoteren van publicaties">
+  <p>
+    Lokale besturen publiceren documenten en beslissingen zoals agenda's, besluitenlijsten, notulen, enz. Opdat de kennis automatisch door een machine uit deze documenten ge&euml;xtraheerd kan worden, moeten ze op een correcte wijze
+    geannoteerd te worden. Deze annotaties gebeuren volgens <a href="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/" target="_blank" rel="noopener">het Besluit Publicatie applicatieprofiel</a> en de <LinkTo @route="docs.submission-annotations">annotaties voor automatische melding</LinkTo>. Dit document beschrijft de annotaties die gebruikt worden om gepubliceerde documenten en overzichtpagina's te annoteren.
+  </p>
+</DocsHeader>
 <section class="region">
   <div class="layout layout--wide">
     <div class="grid">

--- a/app/templates/docs/rijksregisternummer-api.hbs
+++ b/app/templates/docs/rijksregisternummer-api.hbs
@@ -3,7 +3,7 @@
     <div class="tabs__wrapper">
       <ul class="tabs" data-tabs-list>
         <li class="tab">
-          {{#link-to "index" class="tab__link"}}<i class="fa fa-angle-left"></i> Terug naar overzicht{{/link-to}}
+          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
         </li>
       </ul>
     </div>

--- a/app/templates/docs/rijksregisternummer-api.hbs
+++ b/app/templates/docs/rijksregisternummer-api.hbs
@@ -1,23 +1,8 @@
-<section class="region region--alt">
-  <div class="layout layout--wide">
-    <div class="tabs__wrapper">
-      <ul class="tabs" data-tabs-list>
-        <li class="tab">
-          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
-        </li>
-      </ul>
-    </div>
-
-    <div class="grid">
-      <div class="col--8-12 col--1-1--s">
-        <h1 class="h1">Rijksregisternummer naar Persoon URI API [BETA]</h1>
-        <p>
-          Het Rijksregisternummer is een veelgebruikte idenitficator voor een persoon.  Helaas bevat deze identificator persoonlijke informatie zoals het geslacht en de geboortedatum van de persoon waardoor deze niet in alle contexten uitgewisseld kan worden.  Mits het afsluiten van een protocol tussen het bestuur en het Agentschap Binnenlands Bestuur, is het mogelijk om de URI van een persoon op te vragen op basis van het rijksregisternummer.  Dit document beschrijft de API om de URI van een persoon op te vragen op basis van diens rijksregisternummer en de bestuurseenheid waar hij een functie voor uitoefent.
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
+<DocsHeader @heading="Rijksregisternummer naar Persoon URI API [BETA]">
+  <p>
+    Het Rijksregisternummer is een veelgebruikte idenitficator voor een persoon.  Helaas bevat deze identificator persoonlijke informatie zoals het geslacht en de geboortedatum van de persoon waardoor deze niet in alle contexten uitgewisseld kan worden.  Mits het afsluiten van een protocol tussen het bestuur en het Agentschap Binnenlands Bestuur, is het mogelijk om de URI van een persoon op te vragen op basis van het rijksregisternummer.  Dit document beschrijft de API om de URI van een persoon op te vragen op basis van diens rijksregisternummer en de bestuurseenheid waar hij een functie voor uitoefent.
+  </p>
+</DocsHeader>
 
 <section class="region">
   <div class="layout layout--wide">

--- a/app/templates/docs/sparql-endpoint.hbs
+++ b/app/templates/docs/sparql-endpoint.hbs
@@ -3,7 +3,7 @@
     <div class="tabs__wrapper">
       <ul class="tabs" data-tabs-list>
         <li class="tab">
-          {{#link-to "index" class="tab__link"}}<i class="fa fa-angle-left"></i> Terug naar overzicht{{/link-to}}
+          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
         </li>
       </ul>
     </div>

--- a/app/templates/docs/sparql-endpoint.hbs
+++ b/app/templates/docs/sparql-endpoint.hbs
@@ -1,29 +1,15 @@
-<section class="region region--alt">
-  <div class="layout layout--wide">
-    <div class="tabs__wrapper">
-      <ul class="tabs" data-tabs-list>
-        <li class="tab">
-          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
-        </li>
-      </ul>
-    </div>
-    <div class="grid">
-      <div class="col--8-12 col--1-1--s">
-        <h1 class="h1">SPARQL endpoint </h1>
-        <p>
-Dit database-endpoint kan bevraagd worden aan de hand van SPARQL, een query-taal om RDF data te manipuleren. <br>
-RDF is een formaat dat binnen het kader van het semantische web -en dus linked data- zeer vaak voorkomt.
-<br>
-Het LBLOD-project gebruikt RDF intensief.  Verschillende datasets worden gepubliceerd als Turtle en RDFa, serializatie-formaten die de RDF-standaard respecteren.
-<br><br>
-Dit endpoint kan gebruikt worden om rechstreeks op de bron te werken.  Dit helpt niet alleen om het aantal tussenliggende conversies te verminderen, maar ook heel praktisch om complexere bevragingen in minder stappen uit te voeren.
-<br>
-Met SPARQL staat men dichter bij de data, en dus dichter op het model.
-        </p>
-      </div>
-    </div>
-    </div>
-</section>
+<DocsHeader @heading="SPARQL endpoint">
+  <p>
+    Dit database-endpoint kan bevraagd worden aan de hand van SPARQL, een query-taal om RDF data te manipuleren. <br>
+    RDF is een formaat dat binnen het kader van het semantische web -en dus linked data- zeer vaak voorkomt.
+    <br>
+    Het LBLOD-project gebruikt RDF intensief.  Verschillende datasets worden gepubliceerd als Turtle en RDFa, serializatie-formaten die de RDF-standaard respecteren.
+    <br><br>
+    Dit endpoint kan gebruikt worden om rechstreeks op de bron te werken.  Dit helpt niet alleen om het aantal tussenliggende conversies te verminderen, maar ook heel praktisch om complexere bevragingen in minder stappen uit te voeren.
+    <br>
+    Met SPARQL staat men dichter bij de data, en dus dichter op het model.
+  </p>
+</DocsHeader>
 
 <section class="region">
   <div class="layout layout--wide">

--- a/app/templates/docs/submission-annotations.hbs
+++ b/app/templates/docs/submission-annotations.hbs
@@ -3,7 +3,7 @@
     <div class="tabs__wrapper">
       <ul class="tabs" data-tabs-list>
         <li class="tab">
-          {{#link-to "index" class="tab__link"}}<i class="fa fa-angle-left"></i> Terug naar overzicht{{/link-to}}
+          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
         </li>
       </ul>
     </div>
@@ -654,7 +654,7 @@
             <h2 class="h2" id="orgheadline44">Meldingsplicht API</h2>
             <div class="region typography">
               <p class="u-spacer">
-                Bekijk de API die vendors kunnen gebruiken om besluiten te melden: {{#link-to "docs.submission-api"}}Meldingsplicht&nbsp;API{{/link-to}}.
+                Bekijk de API die vendors kunnen gebruiken om besluiten te melden: <LinkTo @route="docs.submission-api">Meldingsplicht&nbsp;API</LinkTo>.
               </p>
             </div>
           </div>

--- a/app/templates/docs/submission-annotations.hbs
+++ b/app/templates/docs/submission-annotations.hbs
@@ -1,23 +1,9 @@
-<section class="region region--alt">
-  <div class="layout layout--wide">
-    <div class="tabs__wrapper">
-      <ul class="tabs" data-tabs-list>
-        <li class="tab">
-          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
-        </li>
-      </ul>
-    </div>
+<DocsHeader @heading="Annotaties voor automatische melding">
+  <p>
+    Lokale besturen publiceren beslissingen die via de Toezicht module in het Loket voor Lokale Besturen gemeld moeten worden. Loket voor Lokale Besturen biedt een API aan waarop publicaties van beslissingen gemeld kunnen worden, waarna ze automatisch geharvest zullen worden en toevoegd worden als nieuwe melding in Loket voor Lokale Besturen. Dit document beschrijft de annotaties die gebruikt worden voor automatische melding.
+  </p>
 
-    <div class="grid">
-      <div class="col--8-12 col--1-1--s">
-        <h1 class="h1">Annotaties voor automatische melding</h1>
-        <p>
-          Lokale besturen publiceren beslissingen die via de Toezicht module in het Loket voor Lokale Besturen gemeld moeten worden. Loket voor Lokale Besturen biedt een API aan waarop publicaties van beslissingen gemeld kunnen worden, waarna ze automatisch geharvest zullen worden en toevoegd worden als nieuwe melding in Loket voor Lokale Besturen. Dit document beschrijft de annotaties die gebruikt worden voor automatische melding.
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
+</DocsHeader>
 
 <section class="region">
   <div class="layout layout--wide">

--- a/app/templates/docs/submission-api.hbs
+++ b/app/templates/docs/submission-api.hbs
@@ -3,7 +3,7 @@
     <div class="tabs__wrapper">
       <ul class="tabs" data-tabs-list>
         <li class="tab">
-          {{#link-to "index" class="tab__link"}}<i class="fa fa-angle-left"></i> Terug naar overzicht{{/link-to}}
+          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
         </li>
       </ul>
     </div>
@@ -37,7 +37,7 @@
               <CodeBlock @language={{snippet.language}}>{{snippet.source}}</CodeBlock>
             {{/let}}
             <p  class="small text-fade u-spacer">
-              Bekijk welke annotaties gebruikt kunnen worden in de gepubliceerde pagina: {{#link-to "docs.submission-annotations"}}annotaties&nbsp;voor&nbsp;automatische&nbsp;melding{{/link-to}}.
+              Bekijk welke annotaties gebruikt kunnen worden in de gepubliceerde pagina: <LinkTo @route="docs.submission-annotations">annotaties&nbsp;voor&nbsp;automatische&nbsp;melding</LinkTo>.
             </p>
           </p>
 
@@ -117,7 +117,7 @@
           <h2 id="publicatie-documenten" class="h2">Publicatie van documenten en besluiten</h2>
           <h3 class="h3">Annotaties voor automatische melding</h3>
           <p class="u-spacer">
-            Bekijk {{#link-to "docs.submission-annotations"}}hier{{/link-to}} welke annotaties gebruikt kunnen worden op de gepubliceerde pagina's om besluiten automatisch te verzenden.
+            Bekijk <LinkTo @route="docs.submission-annotations">hier</LinkTo> welke annotaties gebruikt kunnen worden op de gepubliceerde pagina's om besluiten automatisch te verzenden.
           </p>
           <h3 class="h3">Vereisten voor gepubliceerde pagina's</h3>
           <p class="u-spacer">

--- a/app/templates/docs/submission-api.hbs
+++ b/app/templates/docs/submission-api.hbs
@@ -1,23 +1,8 @@
-<section class="region region--alt">
-  <div class="layout layout--wide">
-    <div class="tabs__wrapper">
-      <ul class="tabs" data-tabs-list>
-        <li class="tab">
-          <LinkTo @route="index" class="tab__link"><i class="fa fa-angle-left"></i> Terug naar overzicht</LinkTo>
-        </li>
-      </ul>
-    </div>
-
-    <div class="grid">
-      <div class="col--8-12 col--1-1--s">
-        <h1 class="h1">Meldingsplicht API</h1>
-        <p>
-          Lokale besturen publiceren beslissingen die via de Toezicht module in het Loket voor Lokale Besturen gemeld moeten worden. Loket voor Lokale Besturen biedt een API aan waarop publicaties van beslissingen gemeld kunnen worden, waarna ze automatisch geharvest zullen worden en toevoegd worden als nieuwe melding in Loket voor Lokale Besturen. Dit document beschrijft de API voor automatische melding.
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
+<DocsHeader @heading="Meldingsplicht API">
+  <p>
+    Lokale besturen publiceren beslissingen die via de Toezicht module in het Loket voor Lokale Besturen gemeld moeten worden. Loket voor Lokale Besturen biedt een API aan waarop publicaties van beslissingen gemeld kunnen worden, waarna ze automatisch geharvest zullen worden en toevoegd worden als nieuwe melding in Loket voor Lokale Besturen. Dit document beschrijft de API voor automatische melding.
+  </p>
+</DocsHeader>
 
 <section class="region">
   <div class="layout layout--wide">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -40,28 +40,28 @@
     <h2 class="h2">Beschikbare documentatie</h2>
     <ul class="grid grid--is-stacked js-equal-height-container">
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
-        {{#link-to "docs.submission-api" class="doormat js-equal-height u-mobile-no-equal-height"}}
+        <LinkTo @route="docs.submission-api" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Meldingsplicht API
           </div>
           <span class="doormat__text">API om een nieuwe melding aan te maken in Loket voor Lokale Besturen op basis van een publicatie. Indien al de nodige velden ingevuld zijn, kan de melding automatisch verzonden worden.</span>
-        {{/link-to}}
+        </LinkTo>
       </li>
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
-        {{#link-to "docs.submission-annotations" class="doormat js-equal-height u-mobile-no-equal-height"}}
+        <LinkTo @route="docs.submission-annotations" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Annotaties voor automatische melding
           </div>
           <span class="doormat__text">Annotaties die gebruikt worden bij automatische meldingen van besluiten en documenten.</span>
-        {{/link-to}}
+        </LinkTo>
       </li>
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
-        {{#link-to "docs.publication-annotations" class="doormat js-equal-height u-mobile-no-equal-height"}}
+        <LinkTo @route="docs.publication-annotations" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Annotaties van besluiten en documenten
           </div>
           <span class="doormat__text">Annotaties die gebruikt worden bij de publicatie van besluiten en documenten opdat ze automatisch geharvest kunnen worden.</span>
-        {{/link-to}}
+        </LinkTo>
       </li>
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
         <a href="https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/" target="_blank" rel="noopener" class="doormat js-equal-height u-mobile-no-equal-height">
@@ -82,28 +82,28 @@
         </a>
       </li>
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
-        {{#link-to "docs.leidinggevenden" class="doormat js-equal-height u-mobile-no-equal-height"}}
+        <LinkTo @route="docs.leidinggevenden" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Leidinggevenden
           </div>
           <span class="doormat__text">De leidinggevenden databank volgt het applicatieprofiel mandatendatabank, maar werd uitgebreid met enkele subklassen en eigenschappen.</span>
-        {{/link-to}}
+        </LinkTo>
       </li>
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
-        {{#link-to "docs.rijksregisternummer-api" class="doormat js-equal-height u-mobile-no-equal-height"}}
+        <LinkTo @route="docs.rijksregisternummer-api" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
             Persoon URI [BETA]
           </div>
           <span class="doormat__text">Bevragen van de URI van een persoon op basis van diens rijksregisternummer en bestuurseenheid.</span>
-        {{/link-to}}
+        </LinkTo>
       </li>
       <li class="col--4-12 col--1-2--s col--12-12--xs" style="min-height: 194px;">
-        {{#link-to "docs.sparql-endpoint" class="doormat js-equal-height u-mobile-no-equal-height"}}
+        <LinkTo @route="docs.sparql-endpoint" class="doormat js-equal-height u-mobile-no-equal-height">
           <div class="doormat__title">
            SPARQL endpoint
           </div>
           <span class="doormat__text">Endpoint om met SPARQL publieke data te bevragen. </span>
-        {{/link-to}}
+        </LinkTo>
       </li>
     </ul>
   </div>

--- a/snippets/example-besluit-met-geannoteerde-bijlage.html
+++ b/snippets/example-besluit-met-geannoteerde-bijlage.html
@@ -23,11 +23,12 @@
   </div>
   <h5>Bijlagen</h5>
   <ul>
-    <li><span resource="http://data.lblod.info/id/besluiten/82b89f09-7398-4c12-890c-a130decac4f8" property="eli:related_to" rev="dct:isPartOf">Gemeentelijk subsidiereglement voor het gebruik van herbruikbare luiers en toebehoren.</span></li>
+    <li><span resource="http://data.lblod.info/id/besluiten/82b89f09-7398-4c12-890c-a130decac4f8" property="eli:related_to">Gemeentelijk subsidiereglement voor het gebruik van herbruikbare luiers en toebehoren.</span></li>
   </ul>
 </div>
 <div property="prov:generated" resource="http://data.lblod.info/id/besluiten/82b89f09-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
-  <h4 class="h4" property="eli:title" datatype="xsd:string">Gemeentelijk subsidiereglement voor het gebruik van herbruikbare luiers en toebehoren.</h4>
+  <span property="dct:isPartOf" resource="http://data.lblod.info/id/besluiten/72b89f05-7398-4c12-890c-a130decac4f8"></span>
+    <h4 class="h4" property="eli:title" datatype="xsd:string">Gemeentelijk subsidiereglement voor het gebruik van herbruikbare luiers en toebehoren.</h4>
   <div property="prov:value" datatype="xsd:string">
     <div property="eli:has_part" resource="http://data.lblod.info/artikels/g3366b82-3751-4333-8531-b9b58b6ccb8d" typeof="besluit:Artikel">
       <div property="eli:number" datatype="xsd:string">Artikel 1</div>

--- a/snippets/example-besluit-met-geannoteerde-bijlage.html
+++ b/snippets/example-besluit-met-geannoteerde-bijlage.html
@@ -23,7 +23,7 @@
   </div>
   <h5>Bijlagen</h5>
   <ul>
-    <li><span resource="http://data.lblod.info/id/besluiten/82b89f09-7398-4c12-890c-a130decac4f8" property="eli:cites" rev="dct:isPartOf">Gemeentelijk subsidiereglement voor het gebruik van herbruikbare luiers en toebehoren.</span></li>
+    <li><span resource="http://data.lblod.info/id/besluiten/82b89f09-7398-4c12-890c-a130decac4f8" property="eli:related_to" rev="dct:isPartOf">Gemeentelijk subsidiereglement voor het gebruik van herbruikbare luiers en toebehoren.</span></li>
   </ul>
 </div>
 <div property="prov:generated" resource="http://data.lblod.info/id/besluiten/82b89f09-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">

--- a/snippets/example-besluit-met-geannoteerde-bijlage.html
+++ b/snippets/example-besluit-met-geannoteerde-bijlage.html
@@ -1,4 +1,4 @@
-<div prefix="eli: http://data.europa.eu/eli/ontology# foaf: http://xmlns.com/foaf/0.1/ besluit: http://data.vlaanderen.be/ns/besluit# prov: http://www.w3.org/ns/prov#" resource="http://data.lblod.info/id/behandeling-van-agendapunten/82b89f04-7398-4c12-890c-a130decac4f8" typeof="besluit:BehandelingVanAgendapunt">
+<div prefix="eli: http://data.europa.eu/eli/ontology# dct: http://purl.org/dc/terms/ foaf: http://xmlns.com/foaf/0.1/ besluit: http://data.vlaanderen.be/ns/besluit# prov: http://www.w3.org/ns/prov#" resource="http://data.lblod.info/id/behandeling-van-agendapunten/82b89f04-7398-4c12-890c-a130decac4f8" typeof="besluit:BehandelingVanAgendapunt">
 <div property="prov:generated" resource="http://data.lblod.info/id/besluiten/72b89f05-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
   <h4 class="h4" property="eli:title" datatype="xsd:string">Goedkeuring gemeentelijk subsidiereglement voor het gebruik van herbruikbare luiers en toebehoren.</h4>
   <span property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">NL</span>

--- a/snippets/example-besluit-met-geannoteerde-bijlage.html
+++ b/snippets/example-besluit-met-geannoteerde-bijlage.html
@@ -1,0 +1,41 @@
+<div prefix="eli: http://data.europa.eu/eli/ontology# foaf: http://xmlns.com/foaf/0.1/ besluit: http://data.vlaanderen.be/ns/besluit# prov: http://www.w3.org/ns/prov#" resource="http://data.lblod.info/id/behandeling-van-agendapunten/82b89f04-7398-4c12-890c-a130decac4f8" typeof="besluit:BehandelingVanAgendapunt">
+<div property="prov:generated" resource="http://data.lblod.info/id/besluiten/72b89f05-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
+  <h4 class="h4" property="eli:title" datatype="xsd:string">Goedkeuring gemeentelijk subsidiereglement voor het gebruik van herbruikbare luiers en toebehoren.</h4>
+  <span property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">NL</span>
+  <p property="eli:description" datatype="xsd:string">De gemeenteraad besliste met algemene stemmen om het nieuw subsidiereglement omtrent het gebruik van herbruikbare luiers en toebehoren voor kinderen van 0 tot 3 jaar, zoals opgenomen in bijlage bij dit besluit, goed te keuren en in werking te laten treden vanaf 1 mei 2019.</p>
+
+  <div property="besluit:motivering" lang="nl">
+    <h5>Juridische context</h5>
+    <ul class="bullet-list">
+      <li>Het decreet<a property="eli:cites" href="https://codex.vlaanderen.be/doc/document/1029017" typeof="http://data.europa.eu/eli/ontology#LegalExpression" >over het lokaal bestuur van 22 december 2017</a>, meer bepaald artikels 40 en 41, betreffende de bevoegdheden van de gemeenteraad.</li>
+    </ul>
+    <br>
+  </div>
+  <h5>Beslissing</h5>
+  <div property="prov:value" datatype="xsd:string">
+    <div property="eli:has_part" resource="http://data.lblod.info/artikels/f3366b82-3751-4333-8531-b9b58b6ccb7f" typeof="besluit:Artikel">
+      <div property="eli:number" datatype="xsd:string">Artikel 1</div>
+      <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">NL</span>
+      <div property="prov:value" datatype="xsd:string">
+        om het nieuwe subsidiereglement omtrent het gebruik van herbruikbare luiers en toebehoren voor kinderen van 0 tot 3 jaar, zoals opgenomen in bijlage bij dit besluit, goed te keuren en in werking te laten treden vanaf 1 mei 2021.
+      </div>
+    </div>
+  </div>
+  <h5>Bijlagen</h5>
+  <ul>
+    <li><span resource="http://data.lblod.info/id/besluiten/82b89f09-7398-4c12-890c-a130decac4f8" property="eli:cites" rev="dct:isPartOf">Gemeentelijk subsidiereglement voor het gebruik van herbruikbare luiers en toebehoren.</span></li>
+  </ul>
+</div>
+<div property="prov:generated" resource="http://data.lblod.info/id/besluiten/82b89f09-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
+  <h4 class="h4" property="eli:title" datatype="xsd:string">Gemeentelijk subsidiereglement voor het gebruik van herbruikbare luiers en toebehoren.</h4>
+  <div property="prov:value" datatype="xsd:string">
+    <div property="eli:has_part" resource="http://data.lblod.info/artikels/g3366b82-3751-4333-8531-b9b58b6ccb8d" typeof="besluit:Artikel">
+      <div property="eli:number" datatype="xsd:string">Artikel 1</div>
+      <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">NL</span>
+      <div property="prov:value" datatype="xsd:string">
+        <strong>Doel</strong> Wegwerpluiers maken een groot deel van de afvalberg uit. In het kader van afvalpreventie, hergebruik en recyclage zijn herbruikbare luiers een goed alternatief voor wegwerpluiers. Het College van Burgemeester en Schepenenvan de gemeente kan -binnen de perken van de jaarlijks op de begroting voorziene en goedgekeurde kredieten-een subsidie toekennen aan mensen die voor hun  kinderen  van  0  tot  3  jaar  herbruikbare  luiers  gebruiken.  Hiermee  wil  de  gemeente  mensen stimuleren  om  op  die  manier  een  bijdrage  te leveren  aan  het  verminderen  van  de  hoeveelheid huishoudelijk restafval.
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/snippets/example-besluit-met-pdf-bijlage-als-onderdeel.html
+++ b/snippets/example-besluit-met-pdf-bijlage-als-onderdeel.html
@@ -13,7 +13,7 @@
   </div>
   <h5>Bijlagen</h5>
   <ul class="bullet-list">
-    <!-- eli:cites wordt gebruikt voor de relatie naar de bijlage,
+    <!-- eli:related_to wordt gebruikt voor de relatie naar de bijlage,
          daarnaast wordt dct:isPartOf gebruikt om aan te geven dat de bijlage kan worden aanzien als een onderdeel van het besluit -->
       <li><a rev="dct:isPartOf" property="eli:related_to" href="https://vlavirgem.be/bijlages/84112ac5-baed-47a7-a90c-a323d54b0e84.pdf" typeof="foaf:Document">Bestek “huur van tijdelijke containerklassen"</a></li>
   </ul>

--- a/snippets/example-besluit-met-pdf-bijlage-als-onderdeel.html
+++ b/snippets/example-besluit-met-pdf-bijlage-als-onderdeel.html
@@ -1,4 +1,4 @@
-<div prefix="foaf: http://xmlns.com/foaf/0.1/ besluit: http://data.vlaanderen.be/ns/besluit# prov: http://www.w3.org/ns/prov#" property="prov:generated" resource="http://data.lblod.info/id/besluiten/72b89f05-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
+<div prefix="dct: http://purl.org/dc/terms/ foaf: http://xmlns.com/foaf/0.1/ besluit: http://data.vlaanderen.be/ns/besluit# prov: http://www.w3.org/ns/prov#" property="prov:generated" resource="http://data.lblod.info/id/besluiten/72b89f05-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
   <h4 class="h4" property="eli:title" datatype="xsd:string">Goedkeuring tot huur van tijdelijke containerklassen</h4>
   <span property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">NL</span>
   <p property="eli:description" datatype="xsd:string">De gemeenteraad besliste om akkoord te gaan met het principe, het bestek en de raming om voor de verbouwing van de gemeenteschool van Laarne gedurende de duur van 13 maanden containerunits te huren bij een leverancier. De kost wordt geraamd op € 85.000,00 incl. BTW</p>
@@ -13,8 +13,9 @@
   </div>
   <h5>Bijlagen</h5>
   <ul class="bullet-list">
-    <!-- eli:cites wordt gebruikt voor een PDF bijlage bij het besluit -->
-    <li><a property="eli:cites" href="https://vlavirgem.be/bijlages/84112ac5-baed-47a7-a90c-a323d54b0e84.pdf" typeof="foaf:Document">Bestek “huur van tijdelijke containerklassen"</a></li>
+    <!-- eli:cites wordt gebruikt voor de relatie naar de bijlage,
+         daarnaast wordt dct:isPartOf gebruikt om aan te geven dat de bijlage kan worden aanzien als een onderdeel van het besluit -->
+      <li><a rev="dct:isPartOf" property="eli:cites" href="https://vlavirgem.be/bijlages/84112ac5-baed-47a7-a90c-a323d54b0e84.pdf" typeof="foaf:Document">Bestek “huur van tijdelijke containerklassen"</a></li>
   </ul>
   <h5>Beslissing</h5>
   <div property="prov:value" datatype="xsd:string">

--- a/snippets/example-besluit-met-pdf-bijlage-als-onderdeel.html
+++ b/snippets/example-besluit-met-pdf-bijlage-als-onderdeel.html
@@ -1,4 +1,4 @@
-<div prefix="dct: http://purl.org/dc/terms/ foaf: http://xmlns.com/foaf/0.1/ besluit: http://data.vlaanderen.be/ns/besluit# prov: http://www.w3.org/ns/prov#" property="prov:generated" resource="http://data.lblod.info/id/besluiten/72b89f05-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
+<div prefix="eli: http://data.europa.eu/eli/ontology# dct: http://purl.org/dc/terms/ foaf: http://xmlns.com/foaf/0.1/ besluit: http://data.vlaanderen.be/ns/besluit# prov: http://www.w3.org/ns/prov#" property="prov:generated" resource="http://data.lblod.info/id/besluiten/72b89f05-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
   <h4 class="h4" property="eli:title" datatype="xsd:string">Goedkeuring tot huur van tijdelijke containerklassen</h4>
   <span property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">NL</span>
   <p property="eli:description" datatype="xsd:string">De gemeenteraad besliste om akkoord te gaan met het principe, het bestek en de raming om voor de verbouwing van de gemeenteschool van Laarne gedurende de duur van 13 maanden containerunits te huren bij een leverancier. De kost wordt geraamd op € 85.000,00 incl. BTW</p>
@@ -15,7 +15,7 @@
   <ul class="bullet-list">
     <!-- eli:cites wordt gebruikt voor de relatie naar de bijlage,
          daarnaast wordt dct:isPartOf gebruikt om aan te geven dat de bijlage kan worden aanzien als een onderdeel van het besluit -->
-      <li><a rev="dct:isPartOf" property="eli:cites" href="https://vlavirgem.be/bijlages/84112ac5-baed-47a7-a90c-a323d54b0e84.pdf" typeof="foaf:Document">Bestek “huur van tijdelijke containerklassen"</a></li>
+      <li><a rev="dct:isPartOf" property="eli:related_to" href="https://vlavirgem.be/bijlages/84112ac5-baed-47a7-a90c-a323d54b0e84.pdf" typeof="foaf:Document">Bestek “huur van tijdelijke containerklassen"</a></li>
   </ul>
   <h5>Beslissing</h5>
   <div property="prov:value" datatype="xsd:string">

--- a/snippets/example-besluit-met-pdf-bijlage.html
+++ b/snippets/example-besluit-met-pdf-bijlage.html
@@ -1,0 +1,31 @@
+<div prefix="foaf: http://xmlns.com/foaf/0.1/ besluit: http://data.vlaanderen.be/ns/besluit# prov: http://www.w3.org/ns/prov#"> property="prov:generated" resource="http://data.lblod.info/id/besluiten/72b89f05-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
+  <h4 class="h4" property="eli:title" datatype="xsd:string">Goedkeuring tot huur van tijdelijke containerklassen</h4>
+  <span property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">NL</span>
+  <p property="eli:description" datatype="xsd:string">De gemeenteraad besliste om akkoord te gaan met het principe, het bestek en de raming om voor de verbouwing van de gemeenteschool van Laarne gedurende de duur van 13 maanden containerunits te huren bij een leverancier. De kost wordt geraamd op € 85.000,00 incl. BTW</p>
+
+  <div property="besluit:motivering" lang="nl">
+    <h5>Juridische context</h5>
+    <ul class="bullet-list">
+      <li>Het decreet<a property="eli:cites" href="https://codex.vlaanderen.be/doc/document/1029017" typeof="http://data.europa.eu/eli/ontology#LegalExpression" >over het lokaal bestuur van 22 december 2017</a>, meer bepaald artikels 40 en 41, betreffende de bevoegdheden van de gemeenteraad.</li>
+    </ul>
+    <br>
+  </div>
+  <h5>Bijlagen</h5>
+  <ul class="bullet-list">
+    <!-- PDF bijlage bij het besluit -->
+    <li><a property="eli:cites" href="https://vlavirgem.be/bijlages/84112ac5-baed-47a7-a90c-a323d54b0e84.pdf" typeof="foaf:Document">Bestek “huur van tijdelijke containerklassen"</a></li>
+  </ul>
+  <h5>Beslissing</h5>
+  <div property="prov:value" datatype="xsd:string">
+    <div property="eli:has_part" resource="http://data.lblod.info/artikels/f3366b82-3751-4333-8531-b9b58b6ccb7f" typeof="besluit:Artikel">
+      <div property="eli:number" datatype="xsd:string">Artikel 1</div>
+      <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
+      <div property="prov:value" datatype="xsd:string">
+        Goedkeuring werd verleend aan...
+      </div>
+    </div>
+    <br>
+    <br>
+  </div>
+
+</div>

--- a/snippets/example-besluit-met-pdf-bijlage.html
+++ b/snippets/example-besluit-met-pdf-bijlage.html
@@ -13,7 +13,7 @@
   </div>
   <h5>Bijlagen</h5>
   <ul class="bullet-list">
-    <!-- eli:cites wordt gebruikt voor een PDF bijlage bij het besluit -->
+    <!-- eli:related_to wordt gebruikt voor een PDF bijlage bij het besluit -->
     <li><a property="eli:related_to" href="https://vlavirgem.be/bijlages/84112ac5-baed-47a7-a90c-a323d54b0e84.pdf" typeof="foaf:Document">Bestek “huur van tijdelijke containerklassen"</a></li>
   </ul>
   <h5>Beslissing</h5>

--- a/snippets/example-besluit-met-pdf-bijlage.html
+++ b/snippets/example-besluit-met-pdf-bijlage.html
@@ -1,4 +1,4 @@
-<div prefix="foaf: http://xmlns.com/foaf/0.1/ besluit: http://data.vlaanderen.be/ns/besluit# prov: http://www.w3.org/ns/prov#" property="prov:generated" resource="http://data.lblod.info/id/besluiten/72b89f05-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
+<div prefix="eli: http://data.europa.eu/eli/ontology# foaf: http://xmlns.com/foaf/0.1/ besluit: http://data.vlaanderen.be/ns/besluit# prov: http://www.w3.org/ns/prov#" property="prov:generated" resource="http://data.lblod.info/id/besluiten/72b89f05-7398-4c12-890c-a130decac4f8" typeof="besluit:Besluit">
   <h4 class="h4" property="eli:title" datatype="xsd:string">Goedkeuring tot huur van tijdelijke containerklassen</h4>
   <span property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">NL</span>
   <p property="eli:description" datatype="xsd:string">De gemeenteraad besliste om akkoord te gaan met het principe, het bestek en de raming om voor de verbouwing van de gemeenteschool van Laarne gedurende de duur van 13 maanden containerunits te huren bij een leverancier. De kost wordt geraamd op € 85.000,00 incl. BTW</p>
@@ -14,7 +14,7 @@
   <h5>Bijlagen</h5>
   <ul class="bullet-list">
     <!-- eli:cites wordt gebruikt voor een PDF bijlage bij het besluit -->
-    <li><a property="eli:cites" href="https://vlavirgem.be/bijlages/84112ac5-baed-47a7-a90c-a323d54b0e84.pdf" typeof="foaf:Document">Bestek “huur van tijdelijke containerklassen"</a></li>
+    <li><a property="eli:related_to" href="https://vlavirgem.be/bijlages/84112ac5-baed-47a7-a90c-a323d54b0e84.pdf" typeof="foaf:Document">Bestek “huur van tijdelijke containerklassen"</a></li>
   </ul>
   <h5>Beslissing</h5>
   <div property="prov:value" datatype="xsd:string">


### PR DESCRIPTION
This is the first of a set of PRs related to attachments, we should provide examples for 
1. non annotated attachments of a decision (this PR)
2. inline annotated attachments of a decision
3. external annotated attachments of a decision

according to the application profile an attachment uses the property "eli:cites" and links to a resource of type "foaf:Document". I've included a citation of a related LegalExpression to make the difference more clear.

NOTE: GN currently doesn't at the LegalExpression type to it's citations.