### PR TITLE
Add documentation to link Eredienstbestuurseenheid from Besluit

### DIFF
--- a/app/templates/docs/submission-annotations.hbs
+++ b/app/templates/docs/submission-annotations.hbs
@@ -521,11 +521,12 @@
   Onderstaande query kan gebruikt worden om gerelateerde Eredienstbestuurseenheden te vinden voor een gegeven Bestuurseenheid. Vervang in onderstaande query de URI voor het Bestuurseenheid met de URI van de betreffende eenheid. Voer deze SPARQL query uit op de <AuLink @route="docs.sparql-endpoint">Centrale Vindplaats</AuLink>.
 </p>
 <SnippetToggle @snippetFilename="annotaties-automatisch-melden-verkrijg-bestuurseenheden.sparql" />
-<!--
+
+<AuHeading @level="4" @skin="4">Voorbeeld</AuHeading>
 <p>
-  Beschouw onderstaand voorbeeld van Besluit waarin wordt verwezen naar een betreffende Bestuurseenheid.
+  Beschouw onderstaand voorbeeld van Besluit waarin wordt verwezen naar een betreffende Bestuurseenheid, direct als eigenschap van het Besluit.
 </p>
--->
+<SnippetToggle @snippetFilename="annotaties-automatisch-melden-rdfa-met-link-bestuurseenheid-voorbeeld.html" />
 
 <AuHeading @level="3" @skin="3">Datetime strings</AuHeading>
 <p>

--- a/app/templates/docs/submission-annotations.hbs
+++ b/app/templates/docs/submission-annotations.hbs
@@ -179,7 +179,7 @@
     </tr>
   </:body>
 </AuTable>
-<AuHeading @level="3" @skin="3">Submitted resource</AuHeading>
+<AuHeading @level="3" @skin="3" id="submitted-resource">Submitted resource</AuHeading>
 <AuHeading @level="4" @skin="4">Klasse</AuHeading>
 <p>
   <CodeInline @code="foaf:Document" /> (meestal <CodeInline @code="besluit:Besluit" />)
@@ -221,7 +221,7 @@
       <td>subject</td>
       <td><CodeInline @code="eli:is_about" /></td>
       <td><CodeInline @code="foaf:Agent" /></td>
-      <td>Agent (organisatie, bestuurseenheid) waarover de beslissing handelt.</td>
+      <td>Agent (organisatie, bestuurseenheid) waarover de beslissing handelt. <br /><strong>Zie onderaan bij "Extra informatie" over <a href="#linken-bestuurseenheid">Linken naar Bestuurseenheid bij sommige Besluittypes</a>.</strong></td>
     </tr>
     <tr>
       <td>reportYear</td>
@@ -484,7 +484,9 @@
     </tr>
   </:body>
 </AuTable>
+
 <AuHeading @level="2" @skin="2">Voorbeelden</AuHeading>
+
 <AuHeading @level="3" @skin="3">Minimale Besluitenlijst</AuHeading>
 <SnippetToggle @snippetFilename="example-besluitenlijst-1.html" />
 
@@ -496,7 +498,35 @@
 
 <AuHeading @level="3" @skin="3">Reglement</AuHeading>
 <SnippetToggle @snippetFilename="example-reglement-1.html" />
+
 <AuHeading @level="2" @skin="2">Extra informatie</AuHeading>
+
+<AuHeading @level="3" @skin="3" id="linken-bestuurseenheid">Linken naar Bestuurseenheid bij sommige Besluittypes</AuHeading>
+
+<p>
+  Bij sommige besluiten is het nodig om te refereren naar een Bestuurseenheid. Hierbij gaat het bijvoorbeeld over de besluiten met volgende types:
+</p>
+<ul>
+  <li>Advies jaarrekening</li>
+  <li>Besluit over budget(wijziging)</li>
+  <li>Besluit over meerjarenplan(aanpassing)</li>
+  <li>Schorsingsbesluit</li>
+  <li>Stuiten</li>
+  <li>Aanvraag desaffectatie presbyteria/kerken</li>
+</ul>
+<p>
+  Om vanuit het Besluit te refereren naar de betreffende Bestuurseenheid via de URI, gebruik het RDF predicaat <CodeInline @code="eli:is_about" />. Zie eveneens bij de bovenstaande tabel onder <a href="#submitted-resource">Submitted Resource</a> voor nog meer eigenschappen voor Besluiten.
+</p>
+<p>
+  Onderstaande query kan gebruikt worden om gerelateerde Eredienstbestuurseenheden te vinden voor een gegeven Bestuurseenheid. Vervang in onderstaande query de URI voor het Bestuurseenheid met de URI van de betreffende eenheid. Voer deze SPARQL query uit op de <AuLink @route="docs.sparql-endpoint">Centrale Vindplaats</AuLink>.
+</p>
+<SnippetToggle @snippetFilename="annotaties-automatisch-melden-verkrijg-bestuurseenheden.sparql" />
+<!--
+<p>
+  Beschouw onderstaand voorbeeld van Besluit waarin wordt verwezen naar een betreffende Bestuurseenheid.
+</p>
+-->
+
 <AuHeading @level="3" @skin="3">Datetime strings</AuHeading>
 <p>
   Bij het verwerken van de <CodeInline @code="xsd:dateTime" /> strings wordt het volgende ondersteund: <br />

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: 'pages-vendors',
     environment,
     rootURL: '/pages-vendors/',
-    locationType: 'hash',
+    locationType: 'history',
     historySupportMiddleware: true,
     routerScroll: {
       scrollElement: '#scroll-to-top-container',

--- a/snippets/annotaties-automatisch-melden-rdfa-met-link-bestuurseenheid-voorbeeld.html
+++ b/snippets/annotaties-automatisch-melden-rdfa-met-link-bestuurseenheid-voorbeeld.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8">
+    <title>Advies Jaarrekening Eredienstbestuur </title>
+  </head>
+  <body>
+    <!-- Een minmaal voorbeeld om advies jaarrekening op te halen via automatische melding -->
+    <!-- Noteer: om de eenvoud te behouden in dit voorbeeld, zijn niet alle verplichte attributen ingevuld -->
+
+    <div vocab="http://data.vlaanderen.be/ns/besluit#" prefix="lblod: http://data.lblod.info/vocabularies/lblod/ eli: http://data.europa.eu/eli/ontology# prov: http://www.w3.org/ns/prov# mandaat: http://data.vlaanderen.be/ns/mandaat# besluit: http://data.vlaanderen.be/ns/besluit# generiek: http://data.vlaanderen.be/ns/generiek# person: http://www.w3.org/ns/person# persoon: http://data.vlaanderen.be/ns/persoon# dct: http://purl.org/dc/terms/ skos: http://www.w3.org/2004/02/skos/core# org: http://www.w3.org/ns/org# foaf: http://xmlns.com/foaf/0.1/ ext: http://mu.semte.ch/vocabularies/ext/ besluittype: https://data.vlaanderen.be/id/concept/BesluitType/ elod: http://linkedeconomy.org/ontology# lblodBesluit: http://lblod.data.gift/vocabularies/besluit/ ">
+
+
+      <!-- ZITTING -->
+      <div typeof="besluit:Zitting" resource="http://een.domein.van.mechelen.be/zittingen/8706fb1c-7394-44f9-82a2-1930b5cb25ca">
+
+        <!--NOTEER: HET GAAT HIER OVER BESTUURSORGAAN IN GEMEENTERAAD BESTUURSPERIODE (2019 - )-->
+        <!--ZIE OOK: https://mandaten.lokaalbestuur.vlaanderen.be/ -->
+        <span
+          resource="http://data.lblod.info/id/bestuursorganen/f7460afee3759df859b3e42f2b108909d2f657726f884427ee0fc915cac45388"
+          typeof="besluit:Bestuursorgaan"
+          property="besluit:isGehoudenDoor">
+          <span resource="http://data.lblod.info/id/bestuursorganen/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda"
+            typeof="besluit:Bestuursorgaan"
+            property="mandaat:isTijdspecialisatieVan">
+            <span property="skos:prefLabel">Gemeenteraad Mechelen</span>
+          </span>
+        </span>
+
+
+        <br>
+        Gehouden op
+        <span property="prov:startedAtTime" content="2023-11-02T17:30:00.000Z" datatype="xsd:dateTime">
+          2 november 2023, 18:30
+        </span>
+
+        <!-- AGENDA -->
+        <span property="besluit:behandelt"
+          resource="http://een.domein.van.mechelen.be/agendapunten/40dbc66c-1957-41fe-95f2-7cd02a73740c"
+          typeof="besluit:Agendapunt">
+          <span property="dc:subject" datatype="xsd:string">Agendapunt</span>
+          <span property="dc:title" datatype="xsd:string">
+            Advies op jaarrekening van Kerkfabriek O.L.V.-Goede-Bijstand van Mechelen
+          </span>
+        </span>
+      </div>
+
+      <!-- BEHANDELING VAN AGENDAPUNT -->
+      <div resource="http://een.domein.van.mechelen.be/behandelingen-van-agendapunten/a4ede6a3-7742-40cb-8776-527748e6b01a"
+        typeof="besluit:BehandelingVanAgendapunt">
+        <h3 property="dc:subject"
+          resource="http://een.domein.van.mechelen.be/agendapunten/40dbc66c-1957-41fe-95f2-7cd02a73740c">
+          Behandeling van het agendapunt 'Advies op jaarrekening van Kerkfabriek O.L.V.-Goede-Bijstand van Mechelen'
+        </h3>
+
+        <!-- BESLUIT -->
+        <!-- ZIE OOK https://github.com/Informatievlaanderen/OSLOthema-lokaleBesluiten VOOR OVERZICHT TYPES -->
+
+        <!--NOTEER:
+             de resource "http://een.domein.van.mechelen.be/besluiten/50d3b372-a666-4434-b824-f94f5aa34ac9"
+             is hetgeen ingestuurd moet worden onder het veld "submittedResource"
+        -->
+
+        <!--NOTEER:
+             https://centrale-vindplaats.lblod.info/sparql kan u ook een overzicht krijgen van de besluittypes
+             + meldingsregels (zie ook sectie meldingsregels op vendor-pages)
+        -->
+
+        <div property="prov:generated" resource="http://een.domein.van.mechelen.be/besluiten/50d3b372-a666-4434-b824-f94f5aa34ac9"
+          typeof="besluit:Besluit https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c">
+          <span property="eli:title" datatype="xsd:string">
+            Goedkeuring jaarrekening van
+
+
+            <!--NOTEER: In de vendor pages vindt u meer informatie over hoe u gerelateerde eredienstbesturen kan vinden
+            -->
+
+            <span property="eli:is_about"
+              resource="http://data.lblod.info/id/besturenVanDeEredienst/05d08699d83c3b2c7fbadc597fb1f721"
+              typeof="http://data.vlaanderen.be/ns/besluit#Bestuurseenheid">
+              Kerkfabriek O.L.V.-Goede-Bijstand van Mechelen
+            </span>
+
+          </span>
+          <br>
+
+          Gepubliceerd op <span property="eli:date_publication" datatype="xsd:date" content="2023-11-02"> 02 november 2023 </span> <br>
+
+          <div property="eli:description" datatype="xsd:string">
+            De <span property="eli:passed_by"
+                 resource="http://data.lblod.info/id/bestuursorganen/f7460afee3759df859b3e42f2b108909d2f657726f884427ee0fc915cac45388">
+            gemeenteraad
+            </span>
+
+            keurt de jaarrekening van het jaar <span property="elod:financialYear" content="2023" datatype="xsd:gYear">2023</span> van de
+            <span property="eli:is_about"
+              resource="http://data.lblod.info/id/besturenVanDeEredienst/05d08699d83c3b2c7fbadc597fb1f721"
+              typeof="http://data.vlaanderen.be/ns/besluit#Bestuurseenheid">
+              Kerkfabriek O.L.V.-Goede-Bijstand van Mechelen
+            </span>
+            goed.
+          </div>
+          <br>
+          <span property="eli:title_short" datatype="xsd:string">Goedkeuring jaarrekening O.L.V.-Goede-Bijstand van Mechelen </span>
+          <div property="besluit:motivering">
+            Gelet op:
+            <span>het decreet
+              <a
+                href="https://codex.vlaanderen.be/doc/document/1029017"
+                property="eli:cites">
+                over het lokaal bestuur
+              </a>
+              inzonderheid de artikelen 40,41 en 330
+            </span>
+            Beslist de gemeenteraad dat,
+            <div property="prov:value" datatype="xsd:string">
+              <div property="eli:has_part"
+                resource="http://een.domein.van.mechelen.be/artikels/53446add-3388-477a-abcb-a230aff04ce7"
+                typeof="besluit:Artikel">
+
+                <div property="eli:number" datatype="xsd:string">Artikel 1 </div>
+                <div property="prov:value" datatype="xsd:string">
+                  De jaarrekening wordt van O.L.V.-Goede-Bijstand van Mechelen goedgekeurd wordt.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/snippets/annotaties-automatisch-melden-verkrijg-bestuurseenheden.sparql
+++ b/snippets/annotaties-automatisch-melden-verkrijg-bestuurseenheden.sparql
@@ -1,0 +1,17 @@
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+PREFIX org:     <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX ere:     <http://data.lblod.info/vocabularies/erediensten/>
+
+SELECT DISTINCT ?eredienst ?label ?classificatieLabel WHERE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4>
+      a besluit:Bestuurseenheid ;
+      ere:betrokkenBestuur ?betrokkenBestuur .
+    ?betrokkenBestuur org:organization ?eredienst .
+    ?eredienst
+      besluit:classificatie ?classificatie ;
+      skos:prefLabel ?label .
+    ?classificatie skos:prefLabel ?classificatieLabel.
+  }
+}


### PR DESCRIPTION
Add some extra explanation on how to link to a Eredienstbestuurseenheid from within a Besluit. This also includes a SPARQL query to get a list of related units from a given Bestuurseenheid.

There is still a comment where an example RDFa document could go, with some more explanation perhaps.