### PR TITLE
Fix routing on GitHub

### DIFF
--- a/app/components/scroll-link.hbs
+++ b/app/components/scroll-link.hbs
@@ -1,0 +1,1 @@
+<a {{on "click" this.performScroll}} href="">{{yield}}</a>

--- a/app/components/scroll-link.js
+++ b/app/components/scroll-link.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class ScrollLinkComponent extends Component {
+  @action
+  performScroll(event) {
+    const element = document.getElementById(this.args.scrollToId);
+    if (element) element.scrollIntoView();
+    event.preventDefault();
+  }
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,2 +1,4 @@
 // EMBER-APPUNIVERSUM
 @import "ember-appuniversum";
+
+@import "./shame.scss";

--- a/app/styles/shame.scss
+++ b/app/styles/shame.scss
@@ -1,0 +1,3 @@
+* {
+  scroll-behavior: smooth;
+}

--- a/app/templates/docs/submission-annotations.hbs
+++ b/app/templates/docs/submission-annotations.hbs
@@ -221,7 +221,7 @@
       <td>subject</td>
       <td><CodeInline @code="eli:is_about" /></td>
       <td><CodeInline @code="foaf:Agent" /></td>
-      <td>Agent (organisatie, bestuurseenheid) waarover de beslissing handelt. <br /><strong>Zie onderaan bij "Extra informatie" over <a href="#linken-bestuurseenheid">Linken naar Bestuurseenheid bij sommige Besluittypes</a>.</strong></td>
+      <td>Agent (organisatie, bestuurseenheid) waarover de beslissing handelt. <br /><strong>Zie onderaan bij "Extra informatie" over <ScrollLink @scrollToId="linken-bestuurseenheid">Linken naar Bestuurseenheid bij sommige Besluittypes</ScrollLink>.</strong></td>
     </tr>
     <tr>
       <td>reportYear</td>
@@ -515,7 +515,7 @@
   <li>Aanvraag desaffectatie presbyteria/kerken</li>
 </ul>
 <p>
-  Om vanuit het Besluit te refereren naar de betreffende Bestuurseenheid via de URI, gebruik het RDF predicaat <CodeInline @code="eli:is_about" />. Zie eveneens bij de bovenstaande tabel onder <a href="#submitted-resource">Submitted Resource</a> voor nog meer eigenschappen voor Besluiten.
+  Om vanuit het Besluit te refereren naar de betreffende Bestuurseenheid via de URI, gebruik het RDF predicaat <CodeInline @code="eli:is_about" />. Zie eveneens bij de bovenstaande tabel onder <ScrollLink @scrollToId="submitted-resource">Submitted Resource</ScrollLink> voor nog meer eigenschappen voor Besluiten.
 </p>
 <p>
   Onderstaande query kan gebruikt worden om gerelateerde Eredienstbestuurseenheden te vinden voor een gegeven Bestuurseenheid. Vervang in onderstaande query de URI voor het Bestuurseenheid met de URI van de betreffende eenheid. Voer deze SPARQL query uit op de <AuLink @route="docs.sparql-endpoint">Centrale Vindplaats</AuLink>.

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: 'pages-vendors',
     environment,
     rootURL: '/pages-vendors/',
-    locationType: 'history',
+    locationType: 'hash',
     historySupportMiddleware: true,
     routerScroll: {
       scrollElement: '#scroll-to-top-container',


### PR DESCRIPTION
This PR creates a new component that allows to scroll to an element on the page for the given id.

The Ember config `locationType: "hash"` has also been restored, to fix the routing issues on GitHub hosting.