### PR TITLE
added an extra example for annotating the decision list

### DIFF
--- a/app/templates/docs/submission-annotations.hbs
+++ b/app/templates/docs/submission-annotations.hbs
@@ -493,6 +493,9 @@
 <AuHeading @level="3" @skin="3">Besluitenlijst met resultaat van de stemming</AuHeading>
 <SnippetToggle @snippetFilename="example-besluitenlijst-2.html" />
 
+<AuHeading @level="3" @skin="3">Uitgebreide Besluitenlijst met titels van agendapunt en resultaat van de stemming</AuHeading>
+<SnippetToggle @snippetFilename="example-besluitenlijst-3.html" />
+
 <AuHeading @level="3" @skin="3">Budget</AuHeading>
 <SnippetToggle @snippetFilename="example-budget-1.html" />
 

--- a/snippets/example-besluitenlijst-3.html
+++ b/snippets/example-besluitenlijst-3.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8">
+    <title>Besluitenlijst gemeenteraad Mechelen</title>
+  </head>
+  <body>
+    <!-- Een uitgebreid voorbeeld om een besluitenlijst met bijhorende stemming in te sturen -->
+    <!-- Noteer: om de eenvoud te behouden in dit voorbeeld, zijn niet alle verplichte attributen ingevuld -->
+    <div>
+      <div
+        vocab="http://data.vlaanderen.be/ns/besluit#"
+        prefix="lblod: http://data.lblod.info/vocabularies/lblod/ eli: http://data.europa.eu/eli/ontology# prov: http://www.w3.org/ns/prov# mandaat: http://data.vlaanderen.be/ns/mandaat# besluit: http://data.vlaanderen.be/ns/besluit# generiek: http://data.vlaanderen.be/ns/generiek# person: http://www.w3.org/ns/person# persoon: http://data.vlaanderen.be/ns/persoon# dct: http://purl.org/dc/terms/ melding: http://lblod.data.gift/vocabularies/automatische-melding/ org: http://www.w3.org/ns/org# elod: http://linkedeconomy.org/ontology# nie: http://www.semanticdesktop.org/ontologies/2007/01/19/nie# nfo: http://www.semanticdesktop.org/ontologies/2007/03/22/nfo# unknown: http://unknown.redpencil.io/ ext: http://mu.semte.ch/vocabularies/ext/ dct: http://purl.org/dc/terms/">
+
+        <!--NOTEER:
+             de resource "http://een.domein.van.mechelen.be/besluitenlijsten/a361ed84-4c47-4ee7-b2f9-2411a15d56ff-6"
+             is hetgeen ingestuurd moet worden onder het veld "submittedResource"
+        -->
+
+        <div typeof="foaf:Document https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee" resource="http://een.domein.van.mechelen.be/besluitenlijsten/a361ed84-4c47-4ee7-b2f9-2411a15d56ff-6">
+          <!-- ZIE OOK:  https://github.com/Informatievlaanderen/OSLOthema-lokaleBesluiten/blob/master/codelijsten/besluit-type.ttl -->
+          <p>
+            <span resource="https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee" property="dct:type">Besluitenlijst</span>
+            goedgekeurd door de
+
+            <!--NOTEER: HET GAAT HIER OVER BESTUURSORGAAN IN GEMEENTERAAD BESTUURSPERIODE (2012-2019) -->
+            <!--ZIE OOK: https://mandaten.lokaalbestuur.vlaanderen.be/ -->
+            <span property="eli:passed_by"
+                  resource="http://data.lblod.info/id/bestuursorganen/9d7f82a31cf7d34f0f5c7a4d53ab3847842b95165ede73a801d41ab685641658"
+            >
+              gemeenteraad Mechelen
+            </span>
+            , gepubliceerd op <span property="eli:date_publication" datatype="xsd:date">2019-03-12</span>
+          </p>
+          <div typeof="besluit:Zitting"
+               resource="http://een.domein.van.mechelen.be/id/zittingen/64e51f37-7b50-48b8-85a0-48bc402ac86f">
+
+            <h1>
+              <span resource="http://een.domein.van.mechelen.be/besluitenlijsten/a361ed84-4c47-4ee7-b2f9-2411a15d56ff-6"
+                    typeof="foaf:Document"
+                    property="besluit:heeftBesluitenlijst">
+                Besluitenlijst
+              </span>
+              van
+
+              <span resource="http://data.lblod.info/id/bestuursorganen/f7460afee3759df859b3e42f2b108909d2f657726f884427ee0fc915cac45388"
+                    typeof="besluit:Bestuursorgaan"
+                    property="besluit:isGehoudenDoor">
+                <!-- voor URIs uit het register van ABB moeten geen prefLabels worden geannotteerd -->
+                Gemeenteraad Mechelen
+              </span>
+            </span>
+
+            , zitting gepland op
+
+            <span property="besluit:geplandeStart"
+                  content="2019-04-13T12:00:00.000Z"
+                  datatype="xsd:dateTime">
+              13 april 2019, 14:00
+            </span>
+
+            en gehouden op
+
+            <span property="prov:startedAtTime"
+                  content="2019-04-13T12:15:00.000Z"
+                  datatype="xsd:dateTime">
+              13 april 2019, 14:15
+            </span>
+            </h1>
+
+            <div>
+              <div property="besluit:behandelt" typeof="besluit:Agendapunt" resource="http://een.domein.van.mechelen.be/id/agendapunten/9c5f2a29-edf2-4510-99b1-e8757c9d01ff">
+                <h3>1. <span property="dc:title">Goedkeuring tijdelijk dienstreglement van de stedelijke openbare bibliotheek n.a.v. verhuis naar 'Het Predikheren'.</span></h3>
+                <div rev="dc:subject" typeof="besluit:BehandelingVanAgendapunt" resource="http://een.domein.van.mechelen.be/id/behandeling-van-agendapunt/9c5f2a29-edd2-4510-99b1-e8757c9d01ff">
+                  <div property="prov:generated" resource="http://een.domein.van.mechelen.be/id/besluiten/70d3dc83-2d2a-4c9e-b980-1d9bd1d1c73b" typeof="besluit:Besluit">
+                    <p property="eli:title">Het besluit van de
+                      <span property="eli:passed_by" resource="http://data.lblod.info/id/bestuursorganen/9d7f82a31cf7d34f0f5c7a4d53ab3847842b95165ede73a801d41ab685641658">
+                        gemeenteraad Mechelen
+                      </span>
+                      tot het verlenen van principiële toestemming voor het zichtbaar gebruik van camera’s door de lokale politie Mechelen-Willebroek op het grondgebied van de stad Mechelen.
+                    </p>
+                  </div>
+                  <h4>Stemmingen</h4>
+                  <div property="besluit:heeftStemming" resource="http://een.domein.van.mechelen.be/id/stemming/bc786227-68e6-47de-a481-4705fac5c055" typeof="besluit:Stemming">
+                    <ul>
+                      <li><span property="besluit:onderwerp">principiële toestemming voor het zichtbaar gebruik van camera’s door de lokale
+                        politie Mechelen-Willebroek op het grondgebied van de stad Mechelen</span>
+                        <span property="besluit:gevolg">goedgekeurd</span>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+              <div property="besluit:behandelt" typeof="besluit:Agendapunt" resource="http://een.domein.van.mechelen.be/id/agendapunten/9c5f2a29-edf2-4510-99b1-e8757c9d01ff">
+                <h3>2. <span property="dc:title">Tijdelijk dienstreglement van de stedelijke openbare bibliotheek n.a.v. verhuis naar 'Het Predikheren'.</span></h3>
+                <!-- de beschrijving van het agendapunt is optioneel -->
+                <p span property="dc:description">Tijdens de maanden juli en augustus zal het niet mogelijk zijn om materialen uit te lenen, daarom wordt voorgesteld de leentermijn te verlengen tot 100 dagen.</p>
+                <div rev="dc:subject" typeof="besluit:BehandelingVanAgendapunt" resource="http://een.domein.van.mechelen.be/id/behandeling-van-agendapunt/9c5f2a29-edd2-4510-99b1-e8757c9d01ff">
+                  <div property="prov:generated" resource="http://een.domein.van.mechelen.be/id/besluiten/70d3dc83-2d2a-4c9e-b980-1d9bd1d1c73b" typeof="besluit:Besluit">
+                    <p property="eli:title">Het besluit van de
+                      <span property="eli:passed_by" resource="http://data.lblod.info/id/bestuursorganen/9d7f82a31cf7d34f0f5c7a4d53ab3847842b95165ede73a801d41ab685641658">
+                        gemeenteraad Mechelen
+                      </span>
+                      tot goedkeuring van het tijdelijk dienstreglement van de stedelijke openbare bibliotheek n.a.v. verhuis naar 'Het Predikheren'.
+                    </p>
+                  </div>
+                  <h4>Stemmingen</h4>
+                  <div property="besluit:heeftStemming" resource="http://een.domein.van.mechelen.be/id/stemming/2a39cda7-88f6-451d-9945-018c5decd290"
+                       typeof="besluit:Stemming">
+                    <ul>
+                      <li><span property="besluit:gevolg">Goedkeuring</span><span property="besluit:gevolg">tijdelijk dienstreglement van de stedelijke openbare bibliotheek n.a.v. verhuis naar 'Het Predikheren'.</span>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+  </body>
+</html>


### PR DESCRIPTION
this should become the preferred way of annotating the decision list since it links the decision to the meeting it was decided in. For now this is not marked as such.

Please review the rdfa carefully.