### PR TITLE
lmb-778: add example data for entiteiten in "mandaten-annotaties"

### DIFF
--- a/app/templates/docs/mandaten-annotaties.hbs
+++ b/app/templates/docs/mandaten-annotaties.hbs
@@ -208,6 +208,8 @@
     </tr>
   </:body>
 </AuTable>
+<AuHeading @level="4" @skin="4">Voorbeeld</AuHeading>
+<SnippetToggle @snippetFilename="mandaten-annotaties/besluit.turtle" />
 
 <AuHeading @level="3" @skin="3">Bestuursorgaan (in bestuursperiode)</AuHeading>
 <AuHeading @level="4" @skin="4">Klasse</AuHeading>
@@ -289,6 +291,8 @@
     </tr>
   </:body>
 </AuTable>
+<AuHeading @level="4" @skin="4">Voorbeeld</AuHeading>
+<SnippetToggle @snippetFilename="mandaten-annotaties/bestuursorgaan.turtle" />
 
 <AuHeading @level="3" @skin="3">Fractie</AuHeading>
 <AuHeading @level="4" @skin="4">Klasse</AuHeading>
@@ -344,6 +348,8 @@
     </tr>
   </:body>
 </AuTable>
+<AuHeading @level="4" @skin="4">Voorbeeld</AuHeading>
+<SnippetToggle @snippetFilename="mandaten-annotaties/fractie.turtle" />
 
 <AuHeading @level="3" @skin="3">Lidmaatschap</AuHeading>
 <AuHeading @level="4" @skin="4">Klasse</AuHeading>
@@ -389,6 +395,8 @@
     </tr>
   </:body>
 </AuTable>
+<AuHeading @level="4" @skin="4">Voorbeeld</AuHeading>
+<SnippetToggle @snippetFilename="mandaten-annotaties/lidmaatschap.turtle" />
 
 <AuHeading @level="3" @skin="3">Mandaat</AuHeading>
 <AuHeading @level="4" @skin="4">Klasse</AuHeading>
@@ -427,6 +435,8 @@
     </tr>
   </:body>
 </AuTable>
+<AuHeading @level="4" @skin="4">Voorbeeld</AuHeading>
+<SnippetToggle @snippetFilename="mandaten-annotaties/mandaat.turtle" />
 
 <AuHeading @level="3" @skin="3">Mandataris</AuHeading>
 <AuHeading @level="4" @skin="4">Klasse</AuHeading>
@@ -564,6 +574,8 @@
 
   </:body>
 </AuTable>
+<AuHeading @level="4" @skin="4">Voorbeeld</AuHeading>
+<SnippetToggle @snippetFilename="mandaten-annotaties/mandataris.turtle" />
 
 <AuHeading @level="3" @skin="3">Persoon</AuHeading>
 <AuHeading @level="4" @skin="4">Klasse</AuHeading>
@@ -610,3 +622,5 @@
     </tr>
   </:body>
 </AuTable>
+<AuHeading @level="4" @skin="4">Voorbeeld</AuHeading>
+<SnippetToggle @snippetFilename="mandaten-annotaties/persoon.turtle" />

--- a/snippets/mandaten-annotaties/besluit.turtle
+++ b/snippets/mandaten-annotaties/besluit.turtle
@@ -1,0 +1,10 @@
+@prefix prov: <http://www.w3.org/ns/prov#>
+@prefix mu: <http://mu.semte.ch/vocabularies/core/>
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+<http://data.lblod.info/id/besluiten/78cf8492-bc57-4ec5-a060-688cfdcfd433> a besluit:Besluit .
+<http://data.lblod.info/id/besluiten/78cf8492-bc57-4ec5-a060-688cfdcfd433> mu:uuid """78cf8492-bc57-4ec5-a060-688cfdcfd433""" .
+<http://data.lblod.info/id/besluiten/78cf8492-bc57-4ec5-a060-688cfdcfd433> mandaat:bekrachtigtAanstellingVan  <http://data.lblod.info/id/mandatarissen/02416d33-b6d4-4e7c-9edb-3a347638b359> .
+<http://data.lblod.info/id/besluiten/78cf8492-bc57-4ec5-a060-688cfdcfd433> mandaat:bekrachtigtOntslagVan  <http://data.lblod.info/id/mandatarissen/3e3da2b1-ce3d-4667-8f79-a03a3c695f98> .
+<http://data.lblod.info/id/besluiten/78cf8492-bc57-4ec5-a060-688cfdcfd433> prov:wasDerivedFrom """https://pittem-echo.cipalschaubroeck.be/id/besluiten/a563148b-2341-4cdf-a6d4-8789a4bf662d""" .

--- a/snippets/mandaten-annotaties/bestuursorgaan.turtle
+++ b/snippets/mandaten-annotaties/bestuursorgaan.turtle
@@ -1,0 +1,12 @@
+@prefix org: <http://www.w3.org/ns/org#>
+@prefix mu: <http://mu.semte.ch/vocabularies/core/>
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+<http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> a besluit:Bestuursorgaan .
+<http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> mu:uuid """b4bdceed-17ee-403e-9943-b131abebd06c""" .
+<http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> org:hasPost <http://data.lblod.info/id/mandaten/C8A92958-F458-11EF-BC01-8152F78DE954> .
+<http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> mandaat:bindingStart """2019-01-01T00:00:00Z"""^^xsd:dateTime .
+<http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> mandaat:bindingEinde """2019-01-01T00:00:00Z"""^^xsd:dateTime .
+<http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> mandaat:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06b> .

--- a/snippets/mandaten-annotaties/bestuursorgaan.turtle
+++ b/snippets/mandaten-annotaties/bestuursorgaan.turtle
@@ -3,10 +3,19 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 @prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 @prefix besluit: <http://data.vlaanderen.be/ns/besluit#>
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>
+@prefix lmb: <http://lblod.data.gift/vocabularies/lmb/>
 
 <http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> a besluit:Bestuursorgaan .
 <http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> mu:uuid """b4bdceed-17ee-403e-9943-b131abebd06c""" .
 <http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> org:hasPost <http://data.lblod.info/id/mandaten/C8A92958-F458-11EF-BC01-8152F78DE954> .
 <http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> mandaat:bindingStart """2019-01-01T00:00:00Z"""^^xsd:dateTime .
 <http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> mandaat:bindingEinde """2019-01-01T00:00:00Z"""^^xsd:dateTime .
-<http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> mandaat:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06b> .
+<http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> lmb:heeftBestuursperiode <http://data.lblod.info/id/concept/Bestuursperiode/9486222f-2696-4811-bde1-fef9dc4b5f68> .
+<http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> mandaat:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/87a30ee7-07d6-455a-9000-de0bfcfb2734> .
+
+<http://data.lblod.info/id/bestuursorganen/87a30ee7-07d6-455a-9000-de0bfcfb2734> a besluit:Bestuursorgaan .
+<http://data.lblod.info/id/bestuursorganen/87a30ee7-07d6-455a-9000-de0bfcfb2734> mu:uuid """87a30ee7-07d6-455a-9000-de0bfcfb2734""" .
+<http://data.lblod.info/id/bestuursorganen/87a30ee7-07d6-455a-9000-de0bfcfb2734> skos:prefLabel """Gemeenteraad""" .
+<http://data.lblod.info/id/bestuursorganen/87a30ee7-07d6-455a-9000-de0bfcfb2734> besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/ae1fba0f-21bd-45e8-8271-567bbe9d3f95> .
+<http://data.lblod.info/id/bestuursorganen/87a30ee7-07d6-455a-9000-de0bfcfb2734> besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005> .

--- a/snippets/mandaten-annotaties/fractie.turtle
+++ b/snippets/mandaten-annotaties/fractie.turtle
@@ -1,0 +1,14 @@
+@prefix org: <http://www.w3.org/ns/org#>
+@prefix regorg: <https://www.w3.org/ns/regorg#>
+@prefix mu: <http://mu.semte.ch/vocabularies/core/>
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/>
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+<http://data.lblod.info/id/fracties/20bb4a2d-dfb7-4655-89a1-9749154cc0cb> a mandaat:Fractie .
+<http://data.lblod.info/id/fracties/20bb4a2d-dfb7-4655-89a1-9749154cc0cb> mu:uuid """20bb4a2d-dfb7-4655-89a1-9749154cc0cb""" .
+<http://data.lblod.info/id/fracties/20bb4a2d-dfb7-4655-89a1-9749154cc0cb> regorg:legalName """Voorbeeld fractie""" .
+<http://data.lblod.info/id/fracties/20bb4a2d-dfb7-4655-89a1-9749154cc0cb> org:memberOf <http://data.lblod.info/id/bestuursorganen/b4bdceed-17ee-403e-9943-b131abebd06c> .
+<http://data.lblod.info/id/fracties/20bb4a2d-dfb7-4655-89a1-9749154cc0cb> ext:isFractietype <http://data.vlaanderen.be/id/concept/Fractietype/Samenwerkingsverband> .
+

--- a/snippets/mandaten-annotaties/lidmaatschap.turtle
+++ b/snippets/mandaten-annotaties/lidmaatschap.turtle
@@ -1,0 +1,7 @@
+@prefix org: <http://www.w3.org/ns/org#>
+@prefix mu: <http://mu.semte.ch/vocabularies/core/>
+
+<http://data.lblod.info/id/lidmaatschappen/6b010532-c611-4700-9b69-da91fe16e4d2> a org:Membership .
+<http://data.lblod.info/id/lidmaatschappen/6b010532-c611-4700-9b69-da91fe16e4d2> mu:uuid """6b010532-c611-4700-9b69-da91fe16e4d2""" .
+<http://data.lblod.info/id/lidmaatschappen/6b010532-c611-4700-9b69-da91fe16e4d2> org:organisation <http://data.lblod.info/id/fracties/672349D9AE5F6D098DC007F4> .
+<http://data.lblod.info/id/lidmaatschappen/6b010532-c611-4700-9b69-da91fe16e4d2> org:memberDuring <http://data.lblod.info/id/tijdsintervallen/6684F966C77ACE4182718B0C> . # Berekend bij publicatie

--- a/snippets/mandaten-annotaties/mandaat.turtle
+++ b/snippets/mandaten-annotaties/mandaat.turtle
@@ -1,0 +1,9 @@
+@prefix org: <http://www.w3.org/ns/org#>
+@prefix mu: <http://mu.semte.ch/vocabularies/core/>
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+
+<http://data.lblod.info/id/mandaten/94f35744-ae50-489d-aca3-9e39966a0f2b> a mandaat:Mandaat .
+<http://data.lblod.info/id/mandaten/94f35744-ae50-489d-aca3-9e39966a0f2b> mu:uuid """94f35744-ae50-489d-aca3-9e39966a0f2b""" .
+<http://data.lblod.info/id/mandaten/94f35744-ae50-489d-aca3-9e39966a0f2b> org:role <http://data.lblod.info/id/lb-mandaat-classificatiecode/22da4572-4818-454b-bbd4-28a9ea97856c> .
+<http://data.lblod.info/id/mandaten/94f35744-ae50-489d-aca3-9e39966a0f2b> mandaat:aantalHouders """1"""^^xsd:Integer .

--- a/snippets/mandaten-annotaties/mandataris.turtle
+++ b/snippets/mandaten-annotaties/mandataris.turtle
@@ -1,0 +1,17 @@
+@prefix org: <http://www.w3.org/ns/org#>
+@prefix mu: <http://mu.semte.ch/vocabularies/core/>
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+@prefix lmb: <http://lblod.data.gift/vocabularies/lmb/>
+
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> a mandaat:Mandataris .
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> mu:uuid """191d7b74-e2b1-4eaa-80ef-71e6ae1850b1""" .
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> org:holds <http://data.lblod.info/id/mandaten/94f35744-ae50-489d-aca3-9e39966a0f2b> .
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> mandaat:start """2024-12-04T23:00:00Z"""^^xsd:dateTime .
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> mandaat:einde """2030-12-31T22:59:59Z"""^^xsd:dateTime .
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75> .
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> mandaat:rangorde """Eerste schepen""" .
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> mandaat:beleidsdomein <http://data.vlaanderen.be/id/concept/BeleidsdomeinCode/5ab10d3a4c934f28dc000029> .
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> org:hasMembership <http://data.lblod.info/id/lidmaatschappen/6b010532-c611-4700-9b69-da91fe16e4d2> .
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6> .
+<http://data.lblod.info/id/mandatarissen/191d7b74-e2b1-4eaa-80ef-71e6ae1850b1> mandaat:isBestuurlijkeAliasVan <http://data.lblod.info/id/personen/c43a7446-c412-4a11-87ab-7b5835065294> .

--- a/snippets/mandaten-annotaties/persoon.turtle
+++ b/snippets/mandaten-annotaties/persoon.turtle
@@ -1,0 +1,10 @@
+@prefix mu: <http://mu.semte.ch/vocabularies/core/>
+@prefix person: <http://www.w3.org/ns/person#>
+@prefix persoon: <http://data.vlaanderen.be/ns/persoon#>
+@prefix foaf: <http://xmlns.com/foaf/0.1/>
+
+<http://data.lblod.info/id/personen/c43a7446-c412-4a11-87ab-7b5835065294> a person:Person .
+<http://data.lblod.info/id/personen/c43a7446-c412-4a11-87ab-7b5835065294> mu:uuid """c43a7446-c412-4a11-87ab-7b5835065294""" .
+<http://data.lblod.info/id/personen/c43a7446-c412-4a11-87ab-7b5835065294> persoon:gebruikteVoornaam """Pascal""" .
+<http://data.lblod.info/id/personen/c43a7446-c412-4a11-87ab-7b5835065294> foaf:familyName """Corneel""" .
+<http://data.lblod.info/id/personen/c43a7446-c412-4a11-87ab-7b5835065294> foaf:name """PC""" .


### PR DESCRIPTION
Added example data for all the "Entiteiten" that where summed up. My example data had some predicates that where not listed in the "Eigenschappen" so removed them from the example.

1. `ember serve`
2. Go to Mandatendatabank
3. A Toggle code snippet should be available under every "Eniteit"
4. Check the data in the example snippet

I used extension `.turtle` here as prism.js does not have `.ttl` extension support