### PR TITLE
ldes documentation for vendors

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -13,6 +13,7 @@ Router.map(function () {
     this.route('publicatie-annotaties');
     this.route('bijlagen-annotaties');
     this.route('leidinggevenden-annotaties');
+    this.route('publicatie-feed');
     //Insturen
     this.route('meldingsplicht');
     this.route('berichtencentrum');

--- a/app/templates/docs/berichtencentrum-sparql.hbs
+++ b/app/templates/docs/berichtencentrum-sparql.hbs
@@ -1,3 +1,4 @@
+
 <AuHeading @skin="1" @level="1">Berichtencentrum SPARQL API <em>[CONCEPT]</em></AuHeading>
 
 <p>

--- a/app/templates/docs/publicatie-feed.hbs
+++ b/app/templates/docs/publicatie-feed.hbs
@@ -1,0 +1,49 @@
+<AuHeading @level="1" @skin="1">Publicaties ontsluiten via LDES</AuHeading>
+<p>Een Linked Data Event Stream (LDES) is een standaardformaat om entiteiten en wijzigingen in tijdreeksen te publiceren als een gestructureerde datastroom. In het kader van een publicatieplatform kan een LDES-feed gebruikt worden om publicaties, inclusief hun locatie, type en publicatiedatum, op een efficiënte en schaalbare manier beschikbaar te maken. Zo kunnen systemen die Linked Data verzamelen (harvesters) eenvoudig de gepubliceerde documenten vinden op het publicatieplatform. Dit document biedt een technische introductie voor ontwikkelaars die een LDES-feed willen toevoegen aan een publicatieplatform.</p>
+
+<AuHeading @level="2" @skin="2" id="annotatie-publicaties">Inhoud van de feed</AuHeading>
+<p>Een LDES-feed is gebaseerd op de RDF-datastructuur en wordt meestal aangeboden via een JSON-LD of Turtle representatie. De basiscomponenten van een LDES-feed zijn:</p>
+<ul>
+  <li><CodeInline @code="Tree:Node" />: Een subverzameling van de stream (paginering).</li>
+  <li><CodeInline @code="Tree:Relation" />: Biedt links naar voorgaande of volgende pagina’s.</li>
+  <li><CodeInline @code="LDES:EventStream" />: Een sequentie van wijzigingen over tijd.</li>
+</ul>
+
+<p>Elke publicatie wordt als een entiteit weergegeven met minimaal:</p>
+<ul>
+  <li><CodeInline @code="dct:isVersionOf"/>: Unieke identificatie van de publicatie.</li>
+  <li><CodeInline @code="prov:atLocation" />: Locatie (URL) van de publicatie.</li>
+  <li><CodeInline @code="dct:type" />: Type van de publicatie.</li>
+  <li><CodeInline @code="prov:generatedAtTime" />: Publicatiedatum van het document</li>
+</ul>
+
+<p>LDES kan aangeboden worden in meerdere serializaties, in dit document gaan we uit van text/turtle serializatie, maar ook JSON-LD is mogelijk. Op het einde van het document worden er voorbeelden voorzien in beide formaten.</p>
+
+<AuHeading @level="3" @skin="3" id="annotatie-publicaties-document-types">Algemene structuur</AuHeading>
+<p>Een Linked Data Event Stream (LDES) (ldes:EventStream) is een verzameling (rdfs:subClassOf tree:Collection) van onveranderlijke objecten, waarbij elk object wordt beschreven met behulp van een set RDF-triples.</p>
+<Snippet @snippetFilename="publicatie-ldes/metadata-structure.turtle" />
+<ul>
+  <li><CodeInline @code="ldes:timestamPath" /> verwijst naar het predicate dat gebruikt wordt in de member om de timestamp van de data te vinden. In dit geval de publicatiedatum van het document</li>
+  <li><CodeInline @code="ldes:versionOfPath" /> verwijst naar het predicate dat wordt gebruikt om te definiëren dat een tree:member van een ldes:EventStream een versie is van een rdf-document. (zie "Versionering")</li>
+  <li><CodeInline @code="tree:shape" /> linkt naar de verwachte vorm van de members en wordt gebruikt voor validatie. Deze mag linken naar de shape gepubliceerd op TODO. Indien de feed meer data bevat dan de minimale set hier beschreven, kan ook een eigen shape gespecifieerd worden.</li>
+  <li><CodeInline @code="tree:member" /> duidt op een member in de verzameling, in dit geval een gepubliceerd document.</li>
+  <li><CodeInline @code="tree:view" /> Linkt naar de huidige node (pagina) in de collectie (zie fragmentering en paginering).</li>
+</ul>
+
+<AuHeading @level="3" @skin="3" id="annotatie-publicaties-document-types">Fragmentering en paginering</AuHeading>
+<p>Als een feed te groot wordt om in één keer op te halen, kan deze worden opgedeeld in kleinere stukken (fragmenten). Dit gebeurt volgens de <AuLinkExternal href="https://treecg.github.io/specification/">TREE-specificatie</AuLinkExternal>, die verschillende manieren biedt om data op te splitsen en te doorzoeken. Zo kan de implementator kiezen om bijvoorbeeld publicaties in stijgende of dalende volgorde van publicatie te publiceren.</p>
+
+<p>Voorbeeld in dalende volgorde (nieuwste eerst): pagina 1 linkt naar pagina 2</p>
+<SnippetToggle @snippetFilename="publicatie-ldes/fragment.turtle" />
+<p>Elke pagina (<CodeInline @code="tree:Node" />) gebruikt TREE-relaties om te navigeren door de publicaties op basis van hun tijdstempel. De <CodeInline @code="tree:LessThanRelation" /> verwijst naar de volgende pagina (page=2), die events bevat met een prov:generatedAtTime kleiner dan "2025-03-22T00:00:00Z".</p>
+
+<p>Voorbeeld in dalende volgorde (nieuwste eerst): pagina 2 linkt naar pagina 1 & 3</p>
+<SnippetToggle @snippetFilename="publicatie-ldes/fragment-2.turtle" />
+<p>De relaties <CodeInline @code="tree:GreaterThanOrEqualToRelation" /> en <CodeInline @code="tree:LessThanRelation" /> definiëren een bereik voor page=2. In dit geval kunnen we dus publicaties met een timestamp tussen 2025-03-22T00:00:00Z en 2025-03-11T12:00:00Z verwachten op pagina 2. Voor oudere publicaties wordt verwezen naar pagina 3, voor nieuwere naar pagina 1.</p>
+  <AuHeading @level="3" @skin="3" id="annotatie-publicaties-document-types">Versionering</AuHeading>
+<p>Als een publicatie wordt geupdate, dan
+</p>
+Dit stelt LDES-afnemers in staat om de geschiedenis van een object te reconstrueren en de meest recente versie te behouden, zonder telkens de volledige LDES-feed opnieuw te moeten verwerken.
+<AuHeading @level="2" @skin="2" id="annotatie-publicaties">Ontdekbaarheid van de feed</AuHeading>
+<p>
+</p>

--- a/app/templates/docs/publicatie-feed.hbs
+++ b/app/templates/docs/publicatie-feed.hbs
@@ -23,7 +23,7 @@
 <p>Een Linked Data Event Stream (LDES) (ldes:EventStream) is een verzameling (rdfs:subClassOf tree:Collection) van onveranderlijke objecten, waarbij elk object wordt beschreven met behulp van een set RDF-triples.</p>
 <Snippet @snippetFilename="publicatie-ldes/metadata-structure.turtle" />
 <ul>
-  <li><CodeInline @code="ldes:timestamPath" /> verwijst naar het predicate dat gebruikt wordt in de member om de timestamp van de data te vinden. In dit geval de publicatiedatum van het document</li>
+  <li><CodeInline @code="ldes:timestampPath" /> verwijst naar het predicate dat gebruikt wordt in de member om de timestamp van de data te vinden. In dit geval de publicatiedatum van het document</li>
   <li><CodeInline @code="ldes:versionOfPath" /> verwijst naar het predicate dat wordt gebruikt om te definiëren dat een tree:member van een ldes:EventStream een versie is van een rdf-document. (zie "Versionering")</li>
   <li><CodeInline @code="tree:shape" /> linkt naar de verwachte vorm van de members en wordt gebruikt voor validatie. Deze mag linken naar de shape gepubliceerd op TODO. Indien de feed meer data bevat dan de minimale set hier beschreven, kan ook een eigen shape gespecifieerd worden.</li>
   <li><CodeInline @code="tree:member" /> duidt op een member in de verzameling, in dit geval een gepubliceerd document.</li>

--- a/app/templates/docs/publicatie-feed.hbs
+++ b/app/templates/docs/publicatie-feed.hbs
@@ -1,7 +1,7 @@
 <AuHeading @level="1" @skin="1">Publicaties ontsluiten via LDES</AuHeading>
 <p>Een Linked Data Event Stream (LDES) is een standaardformaat om entiteiten en wijzigingen in tijdreeksen te publiceren als een gestructureerde datastroom. In het kader van een publicatieplatform kan een LDES-feed gebruikt worden om publicaties, inclusief hun locatie, type en publicatiedatum, op een efficiënte en schaalbare manier beschikbaar te maken. Zo kunnen systemen die Linked Data verzamelen (harvesters) eenvoudig de gepubliceerde documenten vinden op het publicatieplatform. Dit document biedt een technische introductie voor ontwikkelaars die een LDES-feed willen toevoegen aan een publicatieplatform.</p>
 
-<AuHeading @level="2" @skin="2" id="annotatie-publicaties">Inhoud van de feed</AuHeading>
+<AuHeading @level="2" @skin="2" id="inhoud-van-de-feed">Inhoud van de feed</AuHeading>
 <p>Een LDES-feed is gebaseerd op de RDF-datastructuur en wordt meestal aangeboden via een JSON-LD of Turtle representatie. De basiscomponenten van een LDES-feed zijn:</p>
 <ul>
   <li><CodeInline @code="Tree:Node" />: Een subverzameling van de stream (paginering).</li>
@@ -13,13 +13,13 @@
 <ul>
   <li><CodeInline @code="dct:isVersionOf"/>: Unieke identificatie van de publicatie.</li>
   <li><CodeInline @code="prov:atLocation" />: Locatie (URL) van de publicatie.</li>
-  <li><CodeInline @code="dct:type" />: Type van de publicatie.</li>
-  <li><CodeInline @code="prov:generatedAtTime" />: Publicatiedatum van het document</li>
+  <li><CodeInline @code="dct:type" />: Type van de publicatie, uit de <AuLinkExternal href="https://data.vlaanderen.be/doc/concept/BesluitDocumentType/">BesluitDocumentType codelijst</AuLinkExternal>. </li>
+  <li><CodeInline @code="prov:generatedAtTime" />: Publicatiedatum van het document.</li>
 </ul>
 
 <p>LDES kan aangeboden worden in meerdere serializaties, in dit document gaan we uit van text/turtle serializatie, maar ook JSON-LD is mogelijk. Op het einde van het document worden er voorbeelden voorzien in beide formaten.</p>
 
-<AuHeading @level="3" @skin="3" id="annotatie-publicaties-document-types">Algemene structuur</AuHeading>
+<AuHeading @level="3" @skin="3" id="algemene-structuur">Algemene structuur</AuHeading>
 <p>Een Linked Data Event Stream (LDES) (ldes:EventStream) is een verzameling (rdfs:subClassOf tree:Collection) van onveranderlijke objecten, waarbij elk object wordt beschreven met behulp van een set RDF-triples.</p>
 <Snippet @snippetFilename="publicatie-ldes/metadata-structure.turtle" />
 <ul>
@@ -30,20 +30,19 @@
   <li><CodeInline @code="tree:view" /> Linkt naar de huidige node (pagina) in de collectie (zie fragmentering en paginering).</li>
 </ul>
 
-<AuHeading @level="3" @skin="3" id="annotatie-publicaties-document-types">Fragmentering en paginering</AuHeading>
+<AuHeading @level="3" @skin="3" id="fragmentering-en-paginering">Fragmentering en paginering</AuHeading>
 <p>Als een feed te groot wordt om in één keer op te halen, kan deze worden opgedeeld in kleinere stukken (fragmenten). Dit gebeurt volgens de <AuLinkExternal href="https://treecg.github.io/specification/">TREE-specificatie</AuLinkExternal>, die verschillende manieren biedt om data op te splitsen en te doorzoeken. Zo kan de implementator kiezen om bijvoorbeeld publicaties in stijgende of dalende volgorde van publicatie te publiceren.</p>
 
-<p>Voorbeeld in dalende volgorde (nieuwste eerst): pagina 1 linkt naar pagina 2</p>
+<AuHeading @level="4" @skin="4">Voorbeeld in dalende volgorde (nieuwste eerst): pagina 1</AuHeading>
 <SnippetToggle @snippetFilename="publicatie-ldes/fragment.turtle" />
 <p>Elke pagina (<CodeInline @code="tree:Node" />) gebruikt TREE-relaties om te navigeren door de publicaties op basis van hun tijdstempel. De <CodeInline @code="tree:LessThanRelation" /> verwijst naar de volgende pagina (page=2), die events bevat met een prov:generatedAtTime kleiner dan "2025-03-22T00:00:00Z".</p>
 
-<p>Voorbeeld in dalende volgorde (nieuwste eerst): pagina 2 linkt naar pagina 1 & 3</p>
+<AuHeading @level="4" @skin="4">Voorbeeld in dalende volgorde (nieuwste eerst): pagina 2</AuHeading>
 <SnippetToggle @snippetFilename="publicatie-ldes/fragment-2.turtle" />
 <p>De relaties <CodeInline @code="tree:GreaterThanOrEqualToRelation" /> en <CodeInline @code="tree:LessThanRelation" /> definiëren een bereik voor page=2. In dit geval kunnen we dus publicaties met een timestamp tussen 2025-03-22T00:00:00Z en 2025-03-11T12:00:00Z verwachten op pagina 2. Voor oudere publicaties wordt verwezen naar pagina 3, voor nieuwere naar pagina 1.</p>
   <AuHeading @level="3" @skin="3" id="annotatie-publicaties-document-types">Versionering</AuHeading>
-<p>Als een publicatie wordt geupdate, dan
-</p>
-Dit stelt LDES-afnemers in staat om de geschiedenis van een object te reconstrueren en de meest recente versie te behouden, zonder telkens de volledige LDES-feed opnieuw te moeten verwerken.
-<AuHeading @level="2" @skin="2" id="annotatie-publicaties">Ontdekbaarheid van de feed</AuHeading>
+  <p>Als een publicatie wordt geupdate, dan wordt de publicatie nogmaals op de feed gezet. Dit is een nieuwe member met eigen identifier, die naar de "echte" identifier linkt via de <CodeInline @code="dct:isVersionOf" /> relatie. De member krijgt dan een nieuwe <CodeInline @code="prov:generatedAtTime" />.</p>
+  <SnippetToggle @snippetFilename="publicatie-ldes/version-of.turtle" />
+  <p>In bovenstaande voorbeeld werd de besluitenlijst op https://vlavirgem.be/web/BesluitenLijst_Vast%20bureau_13-03-2025.html geupdate met een nieuwe versie vanwege een typfout. De publicatie staat nu 2 keer op de feed: eenmaal op de originele publicatiedatum, en eenmaal met de laatste publicatiedatum op 28 Maart 2025.</p>
 <p>
 </p>

--- a/app/templates/docs/publicatie-feed.hbs
+++ b/app/templates/docs/publicatie-feed.hbs
@@ -1,5 +1,6 @@
-<AuHeading @level="1" @skin="1">Publicaties ontsluiten via LDES</AuHeading>
-<p>Een Linked Data Event Stream (LDES) is een standaardformaat om entiteiten en wijzigingen in tijdreeksen te publiceren als een gestructureerde datastroom. In het kader van een publicatieplatform kan een LDES-feed gebruikt worden om publicaties, inclusief hun locatie, type en publicatiedatum, op een efficiënte en schaalbare manier beschikbaar te maken. Zo kunnen systemen die Linked Data verzamelen (harvesters) eenvoudig de gepubliceerde documenten vinden op het publicatieplatform. Dit document biedt een technische introductie voor ontwikkelaars die een LDES-feed willen toevoegen aan een publicatieplatform.</p>
+<AuHeading @level="1" @skin="1">Publicatie Events ontsluiten via LDES</AuHeading>
+<p>Gepubliceerde documenten kunnen meermaals geupdated worden. Door externe systemen gerichter te laten opvragen wordt de load op de publicatieomgeving en bij de consumenten beperkt. Een Linked Data Event Stream (LDES) laat je toe om te publiceren welke URLs geupdated zijn zodat consumenten gericht komen opvragen.</p>
+<p>LDES is een standaardformaat wat toe laat entiteiten en wijzigingen in tijdreeksen te publiceren als een gestructureerde datastroom. In het kader van een publicatieplatform kan een LDES-feed gebruikt worden om publicaties, inclusief hun locatie, type en publicatiedatum, op een efficiënte en schaalbare manier beschikbaar te stellen. Zo kunnen systemen die Linked Data verzamelen (harvesters) eenvoudig de gepubliceerde documenten vinden op het publicatieplatform. Dit document biedt een technische introductie voor ontwikkelaars die een LDES-feed willen toevoegen aan een publicatieplatform.</p>
 
 <AuHeading @level="2" @skin="2" id="inhoud-van-de-feed">Inhoud van de feed</AuHeading>
 <p>Een LDES-feed is gebaseerd op de RDF-datastructuur en wordt meestal aangeboden via een JSON-LD of Turtle representatie. De basiscomponenten van een LDES-feed zijn:</p>
@@ -32,6 +33,8 @@
 
 <AuHeading @level="3" @skin="3" id="fragmentering-en-paginering">Fragmentering en paginering</AuHeading>
 <p>Als een feed te groot wordt om in één keer op te halen, kan deze worden opgedeeld in kleinere stukken (fragmenten). Dit gebeurt volgens de <AuLinkExternal href="https://treecg.github.io/specification/">TREE-specificatie</AuLinkExternal>, die verschillende manieren biedt om data op te splitsen en te doorzoeken. Zo kan de implementator kiezen om bijvoorbeeld publicaties in stijgende of dalende volgorde van publicatie te publiceren.</p>
+
+<p>Elk individueel fragment is wederom gepubliceerd op een URL. LDES clients behandelen deze individuele documenten.  Om te weten of een pagina gewijzigd is worden de HTTP cache headers gebruikt.  Het is sterk aangewezen op een fragment wat niet meer kan wijzigen op een vaste URL te plaatsen en via HTTP Cache headers aan te geven dat het document niet meer kan wijzigen.</p>
 
 <AuHeading @level="4" @skin="4">Voorbeeld in dalende volgorde (nieuwste eerst): pagina 1</AuHeading>
 <SnippetToggle @snippetFilename="publicatie-ldes/fragment.turtle" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -11531,9 +11531,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001610",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz",
-      "integrity": "sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==",
+      "version": "1.0.30001706",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz",
+      "integrity": "sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==",
       "dev": true,
       "funding": [
         {

--- a/snippets/publicatie-ldes/fragment-2.turtle
+++ b/snippets/publicatie-ldes/fragment-2.turtle
@@ -1,0 +1,28 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix dct:  <http://purl.org/dc/terms/>.
+@prefix ldes: <https://w3id.org/ldes#>.
+@prefix tree: <https://w3id.org/tree#>.
+@prefix members: <http://data.vlavirgem.be/members/>
+
+<https://data.vlavirgem.be/feeds/publicaties> a ldes:EventStream ;
+  # andere attributen weg gelaten voor
+  tree:view  <https://data.vlavirgem.be/feeds/publicaties.ttl?page=1>;
+  tree:member members:da866e3f-ee87-40e1-b923-f94865f76f42.
+
+members:da866e3f-ee87-40e1-b923-f94865f76f42 a foaf:document ;
+  # andere attributen weg gelaten voor duidelijkheid
+   prov:generatedAtTime "2025-03-11T12:00:00Z"^^xsd:dateTime .
+
+<https://data.vlavirgem.be/feeds/publicaties.ttl?page=2> a tree:Node ;
+  tree:relation [
+    a tree:GreaterThanOrEqualToRelation ;
+    tree:node <https://data.vlavirgem.be/feeds/publicaties.ttl?page=1> ;
+    tree:path prov:generatedAtTime ;
+    tree:value "2025-03-22T00:00:00Z"^^xsd:dateTime
+  ], [
+    a tree:LessThanRelation ;
+    tree:node <https://data.vlavirgem.be/feeds/publicaties.ttl?page=3> ;
+    tree:path prov:generatedAtTime ;
+    tree:value "2025-03-11T12:00:00Z"^^xsd:dateTime
+  ] .

--- a/snippets/publicatie-ldes/fragment.turtle
+++ b/snippets/publicatie-ldes/fragment.turtle
@@ -1,0 +1,23 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix dct:  <http://purl.org/dc/terms/>.
+@prefix ldes: <https://w3id.org/ldes#>.
+@prefix tree: <https://w3id.org/tree#>.
+@prefix members: <http://data.vlavirgem.be/members/>
+
+<https://data.vlavirgem.be/feeds/publicaties> a ldes:EventStream ;
+  # andere attributen weg gelaten voor duidelijkheid
+  tree:member members:da866e3f-ee87-40e1-b923-f94865f76f40;
+  tree:view  <https://data.vlavirgem.be/feeds/publicaties.ttl?page=1>.
+
+members:da866e3f-ee87-40e1-b923-f94865f76f40 a foaf:document ;
+  # andere attributen weg gelaten voor duidelijkheid
+   prov:generatedAtTime "2025-03-22T00:00:00Z"^^xsd:dateTime .
+
+<https://data.vlavirgem.be/feeds/publicaties.ttl?page=1> a tree:Node ;
+   tree:relation [
+     a tree:LessThanRelation ;
+     tree:node <https://data.vlavirgem.be/feeds/publicaties.ttl?page=2> ;
+     tree:path prov:generatedAtTime ;
+     tree:value "2025-03-22T00:00:00Z"^^xsd:dateTime
+  ]  .

--- a/snippets/publicatie-ldes/metadata-structure.turtle
+++ b/snippets/publicatie-ldes/metadata-structure.turtle
@@ -1,0 +1,18 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix dct:  <http://purl.org/dc/terms/>.
+@prefix ldes: <https://w3id.org/ldes#>.
+@prefix tree: <https://w3id.org/tree#>.
+@prefix members: <http://data.vlavirgem.be/members/>
+
+<http://data.vlavirgem.be/feeds/publicaties> a ldes:EventStream ;
+  ldes:timestampPath prov:generatedAtTime ;
+  ldes:versionOfPath dc:isVersionOf ;
+  tree:shape ex:shape1.shacl ;
+  tree:view <https://data.vlavirgem.be/feeds/publicaties.ttl??page=1>;
+  tree:member members:da866e3f-ee87-40e1-b923-f94865f76f40.
+
+members:da866e3f-ee87-40e1-b923-f94865f76f40 a foaf:document ;
+  prov:generatedAtTime "2025-03-22T00:00:00Z"^^xsd:dateTime ;
+  prov:atLocation <https://vlavirgem.be/web/BesluitenLijst_Vast%20bureau_13-03-2025.html>;
+  dct:isVersionOf <http://data.vlavirgem.be/publications/94c9e9b7-5b45-4482-b4b1-26688ee9e693>.

--- a/snippets/publicatie-ldes/version-of.turtle
+++ b/snippets/publicatie-ldes/version-of.turtle
@@ -6,11 +6,14 @@
 @prefix members: <http://data.vlavirgem.be/members/>
 
 <http://data.vlavirgem.be/feeds/publicaties> a ldes:EventStream ;
-  ldes:timestampPath prov:generatedAtTime ;
-  ldes:versionOfPath dc:isVersionOf ;
-  tree:shape ex:shape1.shacl ;
-  tree:view <https://data.vlavirgem.be/feeds/publicaties.ttl??page=1>;
-  tree:member members:da866e3f-ee87-40e1-b923-f94865f76f40.
+  # Andere attributen weg gelaten voor duidelijkheid
+  tree:member members:da866e3f-ee87-40e1-b923-f94865f76f40, members:da866e3f-ee87-40e1-b923-f94865f76f42.
+
+members:da866e3f-ee87-40e1-b923-f94865f76f42 a foaf:document ;
+  prov:generatedAtTime "2025-03-28T00:00:00Z"^^xsd:dateTime ;
+  prov:atLocation <https://vlavirgem.be/web/BesluitenLijst_Vast%20bureau_13-03-2025.html>;
+  dct:type <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>;
+  dct:isVersionOf <http://data.vlavirgem.be/publications/94c9e9b7-5b45-4482-b4b1-26688ee9e693>.
 
 members:da866e3f-ee87-40e1-b923-f94865f76f40 a foaf:document ;
   prov:generatedAtTime "2025-03-22T00:00:00Z"^^xsd:dateTime ;


### PR DESCRIPTION
Introduces LDES doc for discovery of publications. to test run locally and surf to http://localhost:4200/pages-vendors/#/docs/publicatie-feed .

Outstanding: 

- [ ] add a shape file that can be linked to and used for validation
- [ ] JSON-LD examples
- [ ] doc on how the feed can be discovered (do we prefer a fixed URL or hinting via headers or meta tags on the portal)